### PR TITLE
Build and install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  release:
+    types: [ created ]
 
 jobs:
 
@@ -26,7 +28,7 @@ jobs:
       uses: golangci/golangci-lint-action@v4.0.0
 
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Docker Build
       run: make docker-build
@@ -38,4 +40,13 @@ jobs:
       uses: vladopajic/go-test-coverage@v2.8.2
       with:
         config: ./.testcoverage.yml
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: build/**/*
+
+    permissions:
+      contents: write
  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: build/**/*
+        files: bin/**/*
 
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: bin/**/*.tar.gz
+        files: |
+          bin/**/*.tar.gz
+          install.sh
 
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ jobs:
       with:
         config: ./.testcoverage.yml
 
+    - name: Build Archives
+      run: make archive
+
     - name: Release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: bin/**/*
+        files: bin/**/*.tar.gz
 
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Code coverage output
 coverage.out
+
+# Build directory
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@
 # Code coverage output
 coverage.out
 
-# Build directory
-build/
+# Bin directory
+bin/

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ CERT_DIR = $(DEV_HABITAT_PATH)/certificates
 
 GOBIN ?= $$(go env GOPATH)/bin
 
+build: $(TOPDIR)/build/amd64-linux/habitat $(TOPDIR)/build/amd64-darwin/habitat
+
 test::
 	go test ./... -timeout 1s
 
@@ -78,3 +80,12 @@ $(CERT_DIR)/dev_root_user_cert.pem: $(CERT_DIR)
 		-out $(CERT_DIR)/dev_root_user_cert.pem \
 		-keyout $(CERT_DIR)/dev_root_user_key.pem \
 		-subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=root"
+
+$(TOPDIR)/build: $(TOPDIR)
+	mkdir -p $(TOPDIR)/build
+
+$(TOPDIR)/build/amd64-linux/habitat: $(TOPDIR)/build
+	GOARCH=amd64 GOOS=linux go build -o $(TOPDIR)/build/amd64-linux/habitat $(TOPDIR)/cmd/node/main.go
+
+$(TOPDIR)/build/amd64-darwin/habitat: $(TOPDIR)/build
+	GOARCH=amd64 GOOS=darwin go build -o $(TOPDIR)/build/amd64-darwin/habitat $(TOPDIR)/cmd/node/main.go

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CERT_DIR = $(DEV_HABITAT_PATH)/certificates
 
 GOBIN ?= $$(go env GOPATH)/bin
 
-build: $(TOPDIR)/build/amd64-linux/habitat $(TOPDIR)/build/amd64-darwin/habitat
+build: $(TOPDIR)/bin/amd64-linux/habitat $(TOPDIR)/bin/amd64-darwin/habitat
 
 test::
 	go test ./... -timeout 1s
@@ -81,11 +81,11 @@ $(CERT_DIR)/dev_root_user_cert.pem: $(CERT_DIR)
 		-keyout $(CERT_DIR)/dev_root_user_key.pem \
 		-subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=root"
 
-$(TOPDIR)/build: $(TOPDIR)
-	mkdir -p $(TOPDIR)/build
+$(TOPDIR)/bin: $(TOPDIR)
+	mkdir -p $(TOPDIR)/bin
 
-$(TOPDIR)/build/amd64-linux/habitat: $(TOPDIR)/build
-	GOARCH=amd64 GOOS=linux go build -o $(TOPDIR)/build/amd64-linux/habitat $(TOPDIR)/cmd/node/main.go
+$(TOPDIR)/bin/amd64-linux/habitat: $(TOPDIR)/bin
+	GOARCH=amd64 GOOS=linux go build -o $(TOPDIR)/bin/amd64-linux/habitat $(TOPDIR)/cmd/node/main.go
 
-$(TOPDIR)/build/amd64-darwin/habitat: $(TOPDIR)/build
-	GOARCH=amd64 GOOS=darwin go build -o $(TOPDIR)/build/amd64-darwin/habitat $(TOPDIR)/cmd/node/main.go
+$(TOPDIR)/bin/amd64-darwin/habitat: $(TOPDIR)/bin
+	GOARCH=amd64 GOOS=darwin go build -o $(TOPDIR)/bin/amd64-darwin/habitat $(TOPDIR)/cmd/node/main.go

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ GOBIN ?= $$(go env GOPATH)/bin
 
 build: $(TOPDIR)/bin/amd64-linux/habitat $(TOPDIR)/bin/amd64-darwin/habitat
 
+archive: $(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz
+
 test::
 	go test ./... -timeout 1s
 
@@ -84,8 +86,16 @@ $(CERT_DIR)/dev_root_user_cert.pem: $(CERT_DIR)
 $(TOPDIR)/bin: $(TOPDIR)
 	mkdir -p $(TOPDIR)/bin
 
+# Linux AMD64 Builds
 $(TOPDIR)/bin/amd64-linux/habitat: $(TOPDIR)/bin
 	GOARCH=amd64 GOOS=linux go build -o $(TOPDIR)/bin/amd64-linux/habitat $(TOPDIR)/cmd/node/main.go
 
+$(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz: $(TOPDIR)/bin/amd64-linux/habitat
+	tar -czf $(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz -C $(TOPDIR)/bin/amd64-linux habitat
+
+# Darwin AMD64 Builds
 $(TOPDIR)/bin/amd64-darwin/habitat: $(TOPDIR)/bin
 	GOARCH=amd64 GOOS=darwin go build -o $(TOPDIR)/bin/amd64-darwin/habitat $(TOPDIR)/cmd/node/main.go
+
+$(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz: $(TOPDIR)/bin/amd64-darwin/habitat
+	tar -czf $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz -C $(TOPDIR)/bin/amd64-darwin habitat

--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@ This repository follows the [standard go project structure](https://github.com/g
  The main application framework is the [Fx](https://uber-go.github.io/fx/) dependency injetion framework. This allows for easy wiring together of components, and testability when components are defined as interfaces. 
 
 
+## Install & Release Process
+To install an officially released version of Habitat, run the following:
+```
+curl -sL https://github.com/eagraf/habitat-new/releases/latest/download/install.sh 2>&1 | bash
+```
+Note: we know that doing this is insecure, but this is a quick way to bootstrap an installation process without too much fuss. Feel free to inspect the installation file before running the command if you are concerned.
+
+The installer will ask you to generate some credentials. If you have done this before, you can skip this step. After finishing the installer, you can now run habitat like this:
+```
+habitat
+```
+
+Currently, there is no way to run Habitat as a daemon, but this will be supported in the future.
+
+### Release Process
+Releases are managed with Github's release feature. When a release is created, a Github action is triggered that builds `.tar.gz` files for all supported platforms, and attaches them as artifacts to the release. The installer script downloads the artifacts for the correct operating system and chip architecture, untars the file, and installs the Habitat binary on the users PATH.

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ mkdir -p "$CERT_DIR"
 
 touch $HOME/.habitat/habitat.yml
 
-read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r
+read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r < /dev/tty
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
     openssl req -newkey rsa:2048 \
@@ -41,7 +41,7 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
         -subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=dev_node"
 fi
 
-read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r
+read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r < /dev/tty
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
     openssl req -newkey rsa:2048 \

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Note, this script is intended to be executed on user machines via curl | bash
+# This is a very simple way to install the script, but it is also very bad security
+# practice to execute scripts from the internet without verifying them first.
+# We are doing this for convenience, but don't take this as a good example of how
+# to do things. You should always verify the contents of a script before executing it.
+
+set -euxo pipefail
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+if [ "$ARCH" == "x86_64" ]; then
+    ARCH="amd64"
+fi
+
+ARCHIVE_URL="https://github.com/eagraf/habitat-new/releases/latest/download/habitat-${ARCH}-${OS}.tar.gz"
+
+TMP_DIR=$(mktemp -d)
+echo "Downloading to $TMP_DIR"
+curl -L $ARCHIVE_URL -o $TMP_DIR/habitat-${ARCH}-${OS}.tar.gz
+mkdir -p $TMP_DIR/habitat-${ARCH}-${OS}
+tar -xzf $TMP_DIR/habitat-${ARCH}-${OS}.tar.gz -C $TMP_DIR/habitat-${ARCH}-${OS}
+
+cp $TMP_DIR/habitat-${ARCH}-${OS}/habitat /usr/local/bin/habitat
+
+mkdir -p $HOME/.habitat
+
+CERT_DIR="$HOME/.habitat/certificates"
+mkdir -p "$CERT_DIR"
+
+touch $HOME/.habitat/habitat.yml
+
+read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]] ; then
+    openssl req -newkey rsa:2048 \
+        -new -nodes -x509 \
+        -out "$CERT_DIR/dev_node_cert.pem" \
+        -keyout "$CERT_DIR/dev_node_key.pem" \
+        -subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=dev_node"
+fi
+
+read -p "Would you like to generate a new user identity key? [y/n]" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]] ; then
+    openssl req -newkey rsa:2048 \
+        -new -nodes -x509 \
+        -out "$CERT_DIR/dev_node_cert.pem" \
+        -keyout "$CERT_DIR/dev_node_key.pem" \
+        -subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=dev_node"
+fi

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
     openssl req -newkey rsa:2048 \
         -new -nodes -x509 \
-        -out "$CERT_DIR/dev_node_cert.pem" \
-        -keyout "$CERT_DIR/dev_node_key.pem" \
+        -out "$CERT_DIR/dev_root_user_cert.pem" \
+        -keyout "$CERT_DIR/dev_root_user_key.pem" \
         -subj "/C=US/ST=California/L=Mountain View/O=Habitat/CN=dev_node"
 fi


### PR DESCRIPTION
A super basic build, release and install process for habitat. Here are the basics:
- Releases are created in the Github UI. When a release is created, a Github action is triggered that builds Habitat for all supported operating systems and chip architectures. When done, each binary is tarred into it's own archive, and then uploaded as an artifact to the release page. In addition, the latest version of an installer script is added as an artifact to the release. You can see an example release here: https://github.com/eagraf/habitat-new/releases/tag/v0.0.1-testing-14
- To install the latest release, run:
 ```
curl -sL https://github.com/eagraf/habitat-new/releases/latest/download/install.sh 2>&1 | bash
```
Note that `curl | bash` is bad security practice, we are just doing this for convenience.

This PR also fixes some bugs that become apparent when using the default value of `HABITAT_PATH`