### PR TITLE
Support atproto personal data server Pt 1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ DOCKER_WORKDIR = /go/src/github.com/eagraf/habitat-new
 # Set up critical Habitat environment variables
 DEV_HABITAT_PATH = $(TOPDIR)/.habitat
 CERT_DIR = $(DEV_HABITAT_PATH)/certificates
+PDS_DIR = $(DEV_HABITAT_PATH)/pds
+PDS_BLOB_DIR = $(PDS_DIR)/blocks
 
 GOBIN ?= $$(go env GOPATH)/bin
 
@@ -35,7 +37,8 @@ lint::
 # To install: https://golangci-lint.run/usage/install/#local-installation
 	CGO_ENABLED=0 golangci-lint run ./...
 
-install:: $(DEV_HABITAT_PATH)/habitat.yml $(CERT_DIR)/dev_node_cert.pem $(CERT_DIR)/dev_root_user_cert.pem
+install:: $(DEV_HABITAT_PATH)/habitat.yml $(CERT_DIR)/dev_node_cert.pem $(CERT_DIR)/dev_root_user_cert.pem $(PDS_BLOB_DIR)
+	go install ./cmd/node
 
 docker-build:
 	docker build -t habitat_node -f ./build/node.dev.Dockerfile .
@@ -58,6 +61,9 @@ $(CERT_DIR): $(DEV_HABITAT_PATH)
 
 $(DEV_HABITAT_PATH)/habitat.yml: $(DEV_HABITAT_PATH)
 	cp $(TOPDIR)/config/habitat.dev.yml $(DEV_HABITAT_PATH)/habitat.yml
+
+$(PDS_BLOB_DIR):
+	mkdir -p $(PDS_BLOB_DIR)
 
 $(CERT_DIR)/dev_node_cert.pem: $(CERT_DIR)
 	@echo "Generating dev node certificate"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ make install
 
 Now you are able to start Habitat. To run the node, run one of the following:
 ```
-make run-dev-compose          # Runs the habitat node in dev mode
+make run-dev      # Runs the habitat node in dev mode
 ```
 To get added to the Tailscale tailnet the first time you run Habitat in dev mode, get an auth key issued from Tailscale and run. You only need to do this once, unless you remove the volumes in `.habitat`.
 ```
-TS_AUTHKEY=<authkey> make run-dev-compose
+TS_AUTHKEY=<authkey> make run-dev
 ```
 The container saves node state in an anonymous volume. If you'd like to run the Habitat node with completely new state, run:
 ```

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -72,6 +72,13 @@ func main() {
 		),
 		fx.Provide(
 			fx.Annotate(
+				reverse_proxy.NewProcessProxyRuleStateUpdateSubscriber,
+				fx.As(new(pubsub.Subscriber[hdb.StateUpdate])),
+				fx.ResultTags(`group:"state_update_subscribers"`),
+			),
+		),
+		fx.Provide(
+			fx.Annotate(
 				processes.NewProcessManager,
 				fx.ParamTags(`group:"process_drivers"`),
 			),

--- a/core/api/node.go
+++ b/core/api/node.go
@@ -17,7 +17,8 @@ type PostAddUserRequest struct {
 }
 
 type PostAppRequest struct {
-	*node.AppInstallation
+	AppInstallation   *node.AppInstallation    `json:"app_installation"`
+	ReverseProxyRules []*node.ReverseProxyRule `json:"reverse_proxy_rules"`
 }
 
 type PostProcessRequest struct {

--- a/core/state/node/core.go
+++ b/core/state/node/core.go
@@ -10,10 +10,11 @@ const AppLifecycleStateInstalling = "installing"
 const AppLifecycleStateInstalled = "installed"
 
 type Package struct {
-	Driver             string `json:"driver"`
-	RegistryURLBase    string `json:"registry_url_base"`
-	RegistryPackageID  string `json:"registry_app_id"`
-	RegistryPackageTag string `json:"registry_tag"`
+	Driver             string                 `json:"driver"`
+	DriverConfig       map[string]interface{} `json:"driver_config"`
+	RegistryURLBase    string                 `json:"registry_url_base"`
+	RegistryPackageID  string                 `json:"registry_app_id"`
+	RegistryPackageTag string                 `json:"registry_tag"`
 }
 
 // TODO some fields should be ignored by the REST api

--- a/core/state/node/core.go
+++ b/core/state/node/core.go
@@ -36,3 +36,19 @@ type Process struct {
 	Created string `json:"created"`
 	Driver  string `json:"driver"`
 }
+
+// ReverseProxyRule matches a URL path to a target of the given type.
+// There are two types of rules currently:
+//  1. File server: serves files from a given directory (useful for serving websites from Habitat)
+//  2. Redirect: redirects to a given URL (useful for exposing APIs for Habitat applications)
+//
+// The matcher field represents the path that the rule should match.
+// The semantics of the target field changes depending on the type. For file servers, it represents the
+// path to the directory to serve files from. For redirects, it represents the URL to redirect to.
+type ReverseProxyRule struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Matcher string `json:"matcher"`
+	Target  string `json:"target"`
+	AppID   string `json:"app_id"`
+}

--- a/core/state/node/migrations.go
+++ b/core/state/node/migrations.go
@@ -299,6 +299,30 @@ var NodeDataMigrations = MigrationsList{
 			return newState, nil
 		},
 	},
+	&basicDataMigration{
+		upVersion:   "v0.0.4",
+		downVersion: "v0.0.3",
+		up: func(state *NodeState) (*NodeState, error) {
+			newState, err := state.Copy()
+			if err != nil {
+				return nil, err
+			}
+			for _, appInstallation := range newState.AppInstallations {
+				appInstallation.DriverConfig = map[string]interface{}{}
+			}
+			return newState, nil
+		},
+		down: func(state *NodeState) (*NodeState, error) {
+			newState, err := state.Copy()
+			if err != nil {
+				return nil, err
+			}
+			for _, appInstallation := range newState.AppInstallations {
+				appInstallation.DriverConfig = nil
+			}
+			return newState, nil
+		},
+	},
 }
 
 func applyPatchToState(diffPatch jsondiff.Patch, state *NodeState) (*NodeState, error) {

--- a/core/state/node/migrations/0000000004-pds.json
+++ b/core/state/node/migrations/0000000004-pds.json
@@ -13,6 +13,28 @@
             "op": "add",
             "path": "/properties/app_installations/additionalProperties/required/9",
             "value": "driver_config"
+        },
+        {
+            "op": "add",
+            "path": "/properties/reverse_proxy_rules",
+            "value": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "type": {
+                            "type": "string",
+                            "enum": [ "file", "redirect" ]
+                        },
+                        "matcher": { "type": "string" },
+                        "target": { "type": "string" },
+                        "app_id": { "type": "string" }
+                    },
+                    "additionalProperties": false,
+                    "required": [ "id", "type", "matcher", "target", "app_id" ]
+                }
+            }
         }
     ],
     "down": [
@@ -24,6 +46,10 @@
             "op": "remove",
             "path": "/properties/app_installations/additionalProperties/required/9",
             "value": "driver_config"
+        },
+        {
+            "op": "remove",
+            "path": "/properties/reverse_proxy_rules"
         }
     ]
 }

--- a/core/state/node/migrations/0000000004-pds.json
+++ b/core/state/node/migrations/0000000004-pds.json
@@ -1,0 +1,29 @@
+{
+    "old_version": "v0.0.3",
+    "new_version": "v0.0.4",
+    "up": [
+        {
+            "op": "add",
+            "path": "/properties/app_installations/additionalProperties/properties/driver_config",
+            "value": {
+                "type": "object"
+            }
+        },
+        {
+            "op": "add",
+            "path": "/properties/app_installations/additionalProperties/required/9",
+            "value": "driver_config"
+        }
+    ],
+    "down": [
+        {
+            "op": "remove",
+            "path": "/properties/app_installations/additionalProperties/properties/driver_config"
+        },
+        {
+            "op": "remove",
+            "path": "/properties/app_installations/additionalProperties/required/9",
+            "value": "driver_config"
+        }
+    ]
+}

--- a/core/state/node/migrations_test.go
+++ b/core/state/node/migrations_test.go
@@ -28,17 +28,16 @@ func TestSchemaMigrations(t *testing.T) {
 
 func TestDataMigrations(t *testing.T) {
 
-	nodeSchema := &NodeSchema{}
-	initState, err := nodeSchema.InitState()
+	initState, err := GetEmptyStateForVersion("v0.0.1")
 	if err != nil {
 		t.Error(err)
 	}
 
-	diffPatch, err := NodeDataMigrations.GetMigrationPatch("v0.0.1", "v0.0.2", initState.(*NodeState))
+	diffPatch, err := NodeDataMigrations.GetMigrationPatch("v0.0.1", "v0.0.2", initState)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(diffPatch))
 
-	updated, err := applyPatchToState(diffPatch, initState.(*NodeState))
+	updated, err := applyPatchToState(diffPatch, initState)
 	assert.Nil(t, err)
 	assert.Equal(t, "test", updated.TestField)
 	assert.Equal(t, "v0.0.2", updated.SchemaVersion)
@@ -67,7 +66,7 @@ func TestDataMigrations(t *testing.T) {
 	assert.Equal(t, "v0.0.2", updated3.SchemaVersion)
 
 	// Test migrating to a nonsensically high version
-	_, err = NodeDataMigrations.GetMigrationPatch("v0.0.1", "v1000.0.4", initState.(*NodeState))
+	_, err = NodeDataMigrations.GetMigrationPatch("v0.0.1", "v1000.0.4", initState)
 	assert.NotNil(t, err)
 }
 

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -214,7 +214,7 @@ func (s *NodeSchema) ValidateState(state []byte) error {
 		return err
 	}
 	if len(keyErrs) > 0 {
-		return fmt.Errorf("validation failed: %v", keyErrs)
+		return keyErrs[0]
 	}
 	return nil
 }

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -12,8 +12,8 @@ import (
 )
 
 const SchemaName = "node"
-const CurrentVersion = "v0.0.1"
-const LatestVersion = "v0.0.3"
+const CurrentVersion = "v0.0.4"
+const LatestVersion = "v0.0.4"
 
 //go:embed schema/schema.json
 var nodeSchemaRaw string

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -21,14 +21,15 @@ var nodeSchemaRaw string
 // TODO structs defined here can embed the immutable structs, but also include mutable fields.
 
 type NodeState struct {
-	NodeID           string                           `json:"node_id"`
-	Name             string                           `json:"name"`
-	Certificate      string                           `json:"certificate"` // TODO turn this into b64
-	SchemaVersion    string                           `json:"schema_version"`
-	TestField        string                           `json:"test_field,omitempty"`
-	Users            map[string]*User                 `json:"users"`
-	Processes        map[string]*ProcessState         `json:"processes"`
-	AppInstallations map[string]*AppInstallationState `json:"app_installations"`
+	NodeID            string                           `json:"node_id"`
+	Name              string                           `json:"name"`
+	Certificate       string                           `json:"certificate"` // TODO turn this into b64
+	SchemaVersion     string                           `json:"schema_version"`
+	TestField         string                           `json:"test_field,omitempty"`
+	Users             map[string]*User                 `json:"users"`
+	Processes         map[string]*ProcessState         `json:"processes"`
+	AppInstallations  map[string]*AppInstallationState `json:"app_installations"`
+	ReverseProxyRules *map[string]*ReverseProxyRule    `json:"reverse_proxy_rules,omitempty"`
 }
 
 type User struct {
@@ -90,6 +91,24 @@ func (s NodeState) GetProcessesForUser(userID string) ([]*ProcessState, error) {
 	return procs, nil
 }
 
+func (s NodeState) GetReverseProxyRulesForProcess(processID string) ([]*ReverseProxyRule, error) {
+	process, ok := s.Processes[processID]
+	if !ok {
+		return nil, fmt.Errorf("process with ID %s not found", processID)
+	}
+	app, ok := s.AppInstallations[process.AppID]
+	if !ok {
+		return nil, fmt.Errorf("app with ID %s not found", process.AppID)
+	}
+	rules := make([]*ReverseProxyRule, 0)
+	for _, rule := range *s.ReverseProxyRules {
+		if rule.AppID == app.ID {
+			rules = append(rules, rule)
+		}
+	}
+	return rules, nil
+}
+
 func (s NodeState) Copy() (*NodeState, error) {
 	marshaled, err := s.Bytes()
 	if err != nil {
@@ -120,8 +139,9 @@ func (s NodeState) Validate() error {
 		return err
 	}
 
+	// Just return the first error.
 	if len(keyErrs) > 0 {
-		return fmt.Errorf("validation failed: %v", keyErrs)
+		return keyErrs[0]
 	}
 	return nil
 }
@@ -133,12 +153,9 @@ func (s *NodeSchema) Name() string {
 }
 
 func (s *NodeSchema) InitState() (hdb.State, error) {
-	return &NodeState{
-		SchemaVersion:    CurrentVersion,
-		Users:            make(map[string]*User),
-		Processes:        make(map[string]*ProcessState),
-		AppInstallations: make(map[string]*AppInstallationState),
-	}, nil
+
+	return GetEmptyStateForVersion(CurrentVersion)
+
 }
 
 func (s *NodeSchema) Type() reflect.Type {

--- a/core/state/node/schema/schema.json
+++ b/core/state/node/schema/schema.json
@@ -40,6 +40,9 @@
                         "type": "string",
                         "enum": [ "docker" ]
                     },
+                    "driver_config": {
+                        "type": "object"
+                    },
                     "registry_url_base": { "type": "string" },
                     "registry_app_id": { "type": "string" },
                     "registry_tag": { "type": "string" },
@@ -49,7 +52,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "required": [ "id", "name", "user_id", "version", "driver", "registry_url_base", "registry_app_id", "registry_tag", "state" ]
+                "required": [ "id", "name", "user_id", "version", "driver", "registry_url_base", "registry_app_id", "registry_tag", "state",  "driver_config" ]
             }
         },
         "processes": {

--- a/core/state/node/schema/schema.json
+++ b/core/state/node/schema/schema.json
@@ -74,6 +74,24 @@
                 "additionalProperties": false,
                 "required": [ "id", "app_id", "driver", "ext_driver_id", "user_id", "state", "created" ]
             }
+        },
+        "reverse_proxy_rules": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string"},
+                    "type": {
+                        "type": "string",
+                        "enum": [ "file", "redirect" ]
+                    },
+                    "matcher": { "type": "string" },
+                    "target": { "type": "string" },
+                    "app_id": { "type": "string" }
+                },
+                "additionalProperties": false,
+                "required": [ "id", "type", "matcher", "target", "app_id" ]
+            }
         }
     },
     "additionalProperties": false,

--- a/core/state/node/schema_test.go
+++ b/core/state/node/schema_test.go
@@ -71,3 +71,58 @@ func TestGetAppByID(t *testing.T) {
 	_, err = state.GetAppByID("app2")
 	assert.NotNil(t, err)
 }
+
+func TestGetReverseProxyRulesForProcess(t *testing.T) {
+
+	state := &NodeState{
+		AppInstallations: map[string]*AppInstallationState{
+			"app1": {
+				AppInstallation: &AppInstallation{
+					ID: "app1",
+				},
+			},
+		},
+		Processes: map[string]*ProcessState{
+			"process1": {
+				Process: &Process{
+					ID:    "process1",
+					AppID: "app1",
+				},
+			},
+			"process2": {
+				Process: &Process{
+					ID:    "process2",
+					AppID: "non-existant-this-shouldn'thappen",
+				},
+			},
+		},
+		ReverseProxyRules: &map[string]*ReverseProxyRule{
+			"rule1": {
+				ID:    "rule1",
+				AppID: "app1",
+			},
+		},
+	}
+
+	rules, err := state.GetReverseProxyRulesForProcess("process1")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(rules))
+	assert.Equal(t, "rule1", rules[0].ID)
+
+	_, err = state.GetReverseProxyRulesForProcess("nonexistant")
+	assert.NotNil(t, err)
+}
+
+func TestGetEmptyStateForVersion(t *testing.T) {
+	_, err := GetEmptyStateForVersion("v1")
+	assert.NotNil(t, err)
+
+	state, err := GetEmptyStateForVersion("v0.0.1")
+	assert.Nil(t, err)
+	assert.NotNil(t, state)
+
+	state, err = GetEmptyStateForVersion("v0.0.4")
+	assert.Nil(t, err)
+	assert.NotNil(t, state)
+	assert.NotNil(t, state.ReverseProxyRules)
+}

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -42,10 +42,10 @@ func (t *InitalizationTransition) Patch(oldState []byte) ([]byte, error) {
 		t.InitState.Processes = make(map[string]*ProcessState)
 	}
 
-	if t.InitState.ReverseProxyRules == nil {
-		rules := make(map[string]*ReverseProxyRule)
-		t.InitState.ReverseProxyRules = &rules
-	}
+	//	if t.InitState.ReverseProxyRules == nil {
+	//rules := make(map[string]*ReverseProxyRule)
+	//t.InitState.ReverseProxyRules = &rules
+	//}
 
 	marshaled, err := json.Marshal(t.InitState)
 	if err != nil {

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -42,11 +42,6 @@ func (t *InitalizationTransition) Patch(oldState []byte) ([]byte, error) {
 		t.InitState.Processes = make(map[string]*ProcessState)
 	}
 
-	//	if t.InitState.ReverseProxyRules == nil {
-	//rules := make(map[string]*ReverseProxyRule)
-	//t.InitState.ReverseProxyRules = &rules
-	//}
-
 	marshaled, err := json.Marshal(t.InitState)
 	if err != nil {
 		return nil, err

--- a/core/state/node/transitions_test.go
+++ b/core/state/node/transitions_test.go
@@ -192,6 +192,7 @@ func TestAppLifecycle(t *testing.T) {
 					DriverConfig:       map[string]interface{}{},
 				},
 			},
+			NewProxyRules: []*ReverseProxyRule{},
 		},
 	}
 

--- a/core/state/node/transitions_test.go
+++ b/core/state/node/transitions_test.go
@@ -169,7 +169,7 @@ func TestAppLifecycle(t *testing.T) {
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
-				SchemaVersion: "v0.0.1",
+				SchemaVersion: LatestVersion,
 				Users:         make(map[string]*User, 0),
 			},
 		},
@@ -189,6 +189,7 @@ func TestAppLifecycle(t *testing.T) {
 					RegistryURLBase:    "https://registry.com",
 					RegistryPackageID:  "app_name1",
 					RegistryPackageTag: "v1",
+					DriverConfig:       map[string]interface{}{},
 				},
 			},
 		},
@@ -313,7 +314,7 @@ func TestProcesses(t *testing.T) {
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
-				SchemaVersion: "v0.0.1",
+				SchemaVersion: LatestVersion,
 				Users: map[string]*User{
 					"123": {
 						ID:          "123",
@@ -332,6 +333,7 @@ func TestProcesses(t *testing.T) {
 								RegistryURLBase:    "https://registry.com",
 								RegistryPackageID:  "app_name1",
 								RegistryPackageTag: "v1",
+								DriverConfig:       map[string]interface{}{},
 							},
 						},
 						State: "installed",

--- a/core/state/node/transitions_test.go
+++ b/core/state/node/transitions_test.go
@@ -307,6 +307,54 @@ func TestAppLifecycle(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestAppInstallReverseProxyRules(t *testing.T) {
+	proxyRules := make(map[string]*ReverseProxyRule)
+	transitions := []hdb.Transition{
+		&InitalizationTransition{
+			InitState: &NodeState{
+				NodeID:            "abc",
+				Certificate:       "123",
+				Name:              "New Node",
+				SchemaVersion:     LatestVersion,
+				Users:             make(map[string]*User, 0),
+				ReverseProxyRules: &proxyRules,
+			},
+		},
+		&AddUserTransition{
+			UserID:      "123",
+			Username:    "eagraf",
+			Certificate: "placeholder",
+		},
+		&StartInstallationTransition{
+			UserID: "123",
+			AppInstallation: &AppInstallation{
+				UserID:  "123",
+				Name:    "app_name1",
+				Version: "1",
+				Package: Package{
+					Driver:             "docker",
+					RegistryURLBase:    "https://registry.com",
+					RegistryPackageID:  "app_name1",
+					RegistryPackageTag: "v1",
+					DriverConfig:       map[string]interface{}{},
+				},
+			},
+			NewProxyRules: []*ReverseProxyRule{
+				{
+					AppID:   "app1",
+					Matcher: "/path",
+					Target:  "http://localhost:8080",
+					Type:    "redirect",
+				},
+			},
+		},
+	}
+
+	newState, err := testTransitions(nil, transitions)
+	assert.Nil(t, err)
+	assert.NotNil(t, newState)
+}
+
 func TestProcesses(t *testing.T) {
 
 	transitions := []hdb.Transition{

--- a/internal/node/api/server.go
+++ b/internal/node/api/server.go
@@ -27,7 +27,7 @@ func NewAPIServer(lc fx.Lifecycle, router *mux.Router, logger *zerolog.Logger, p
 			srv.TLSConfig = tlsConfig
 
 			// Start the server
-			url, err := url.Parse("http://localhost:3000")
+			url, err := url.Parse("https://localhost:3000")
 			if err != nil {
 				return fmt.Errorf("error parsing URL: %s", err)
 			}

--- a/internal/node/api/server.go
+++ b/internal/node/api/server.go
@@ -2,12 +2,9 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/constants"
@@ -23,7 +20,7 @@ func NewAPIServer(lc fx.Lifecycle, router *mux.Router, logger *zerolog.Logger, p
 	srv := &http.Server{Addr: fmt.Sprintf(":%s", constants.DefaultPortHabitatAPI), Handler: router}
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			tlsConfig, err := generateTLSConfig(nodeConfig)
+			tlsConfig, err := nodeConfig.TLSConfig()
 			if err != nil {
 				return err
 			}
@@ -32,14 +29,14 @@ func NewAPIServer(lc fx.Lifecycle, router *mux.Router, logger *zerolog.Logger, p
 			// Start the server
 			url, err := url.Parse("http://localhost:3000")
 			if err != nil {
-				return fmt.Errorf("Error parsing URL: %s", err)
+				return fmt.Errorf("error parsing URL: %s", err)
 			}
 			err = proxyRules.Add("Habitat API", &reverse_proxy.RedirectRule{
 				ForwardLocation: url,
 				Matcher:         "/habitat/api",
 			})
 			if err != nil {
-				return fmt.Errorf("Error adding proxy rule: %s", err)
+				return fmt.Errorf("error adding proxy rule: %s", err)
 			}
 
 			logger.Info().Msgf("Starting Habitat API server at %s", srv.Addr)
@@ -54,19 +51,4 @@ func NewAPIServer(lc fx.Lifecycle, router *mux.Router, logger *zerolog.Logger, p
 		},
 	})
 	return srv
-}
-
-func generateTLSConfig(config *config.NodeConfig) (*tls.Config, error) {
-	rootCertBytes, err := os.ReadFile(config.RootUserCertPath())
-	if err != nil {
-		return nil, err
-	}
-
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(rootCertBytes)
-
-	return &tls.Config{
-		ClientCAs:  caCertPool,
-		ClientAuth: tls.RequireAndVerifyClientCert,
-	}, nil
 }

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -135,6 +136,21 @@ func (n *NodeConfig) RootUserCertPath() string {
 
 func (n *NodeConfig) RootUserCertB64() string {
 	return base64.StdEncoding.EncodeToString(n.RootUserCert.Raw)
+}
+
+func (n *NodeConfig) TLSConfig() (*tls.Config, error) {
+	rootCertBytes, err := os.ReadFile(n.RootUserCertPath())
+	if err != nil {
+		return nil, err
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(rootCertBytes)
+
+	return &tls.Config{
+		ClientCAs:  caCertPool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+	}, nil
 }
 
 // Currently unused, but may be necessary to implement adding members to the community.

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -23,7 +23,7 @@ type NodeController interface {
 	AddUser(userID, username, certificate string) error
 	GetUserByUsername(username string) (*node.User, error)
 
-	InstallApp(userID string, newApp *node.AppInstallation) error
+	InstallApp(userID string, newApp *node.AppInstallation, newProxyRules []*node.ReverseProxyRule) error
 	FinishAppInstallation(userID string, appID, registryURLBase, registryPackageID string) error
 	GetAppByID(appID string) (*node.AppInstallation, error)
 
@@ -77,7 +77,7 @@ func (c *BaseNodeController) MigrateNodeDB(targetVersion string) error {
 }
 
 // InstallApp attempts to install the given app installation, with the userID as the action initiato.
-func (c *BaseNodeController) InstallApp(userID string, newApp *node.AppInstallation) error {
+func (c *BaseNodeController) InstallApp(userID string, newApp *node.AppInstallation, newProxyRules []*node.ReverseProxyRule) error {
 	dbClient, err := c.databaseManager.GetDatabaseClientByName(constants.NodeDBDefaultName)
 	if err != nil {
 		return err
@@ -87,6 +87,7 @@ func (c *BaseNodeController) InstallApp(userID string, newApp *node.AppInstallat
 		&node.StartInstallationTransition{
 			UserID:          userID,
 			AppInstallation: newApp,
+			NewProxyRules:   newProxyRules,
 		},
 	})
 	return err

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -140,6 +140,7 @@ func TestInstallAppController(t *testing.T) {
 						RegistryPackageTag: "v1",
 					},
 				},
+				NewProxyRules: []*node.ReverseProxyRule{},
 			},
 		},
 	)).Return(nil, nil).Times(1)
@@ -153,7 +154,7 @@ func TestInstallAppController(t *testing.T) {
 			RegistryPackageID:  "app_name1",
 			RegistryPackageTag: "v1",
 		},
-	})
+	}, []*node.ReverseProxyRule{})
 	assert.Nil(t, err)
 }
 

--- a/internal/node/controller/mocks/mock_controller.go
+++ b/internal/node/controller/mocks/mock_controller.go
@@ -112,17 +112,17 @@ func (mr *MockNodeControllerMockRecorder) InitializeNodeDB() *gomock.Call {
 }
 
 // InstallApp mocks base method.
-func (m *MockNodeController) InstallApp(userID string, newApp *node.AppInstallation) error {
+func (m *MockNodeController) InstallApp(userID string, newApp *node.AppInstallation, newProxyRules []*node.ReverseProxyRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallApp", userID, newApp)
+	ret := m.ctrl.Call(m, "InstallApp", userID, newApp, newProxyRules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallApp indicates an expected call of InstallApp.
-func (mr *MockNodeControllerMockRecorder) InstallApp(userID, newApp any) *gomock.Call {
+func (mr *MockNodeControllerMockRecorder) InstallApp(userID, newApp, newProxyRules any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallApp", reflect.TypeOf((*MockNodeController)(nil).InstallApp), userID, newApp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallApp", reflect.TypeOf((*MockNodeController)(nil).InstallApp), userID, newApp, newProxyRules)
 }
 
 // MigrateNodeDB mocks base method.

--- a/internal/node/controller/routes.go
+++ b/internal/node/controller/routes.go
@@ -101,7 +101,7 @@ func (h *InstallAppRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	appInstallation := req.AppInstallation
 	appInstallation.UserID = userID
 
-	err = h.nodeController.InstallApp(userID, appInstallation)
+	err = h.nodeController.InstallApp(userID, appInstallation, req.ReverseProxyRules)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/node/controller/routes_test.go
+++ b/internal/node/controller/routes_test.go
@@ -95,6 +95,7 @@ func TestInstallAppHandler(t *testing.T) {
 				RegistryPackageTag: "v1",
 			},
 		},
+		ReverseProxyRules: []*node.ReverseProxyRule{},
 	}
 
 	bodyBytes, err := json.Marshal(body)
@@ -104,7 +105,7 @@ func TestInstallAppHandler(t *testing.T) {
 
 	testAppInstallation := body.AppInstallation
 	testAppInstallation.UserID = "0"
-	m.EXPECT().InstallApp("0", testAppInstallation).Return(nil).Times(1)
+	m.EXPECT().InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).Return(nil).Times(1)
 
 	client := server.Client()
 	url := fmt.Sprintf("%s/node/users/0/apps", server.URL)
@@ -119,7 +120,7 @@ func TestInstallAppHandler(t *testing.T) {
 	assert.Equal(t, 0, len(respBody))
 
 	// Test an error returned by the controller
-	m.EXPECT().InstallApp("0", testAppInstallation).Return(errors.New("Couldn't install app")).Times(1)
+	m.EXPECT().InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).Return(errors.New("Couldn't install app")).Times(1)
 	resp, err = client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)

--- a/internal/node/docker/driver.go
+++ b/internal/node/docker/driver.go
@@ -17,11 +17,44 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Example docker driver configuration for a container configuration:
+
+/**
+	"driver_config": {
+		"env": [
+			"PDS_HOSTNAME=ethangraf.com",
+			"PDS_DATA_DIRECTORY=/pds",
+		],
+		"mounts": [
+			{
+				"Type": "bind",
+				"Source": "/Users/ethan/code/habitat/habitat-new/.habitat/pds",
+				"Target": "/pds"
+			}
+		],
+		"exposed_ports": [ "5000" ],
+		"port_bindings": {
+			"3000/tcp": [
+				{
+					"hostIp": "127.0.0.1",
+					"hostPort": "5000"
+				}
+			]
+		}
+	}
+**/
+
+// DockerAppInstallationConfig is a struct to hold the configuration for a docker container
+// Most of these types are taken directly from the Docker Go SDK
 type DockerAppInstallationConfig struct {
-	ExposedPorts []string      `json:"exposed_ports"`
-	Env          []string      `json:"env"`
-	PortBindings nat.PortMap   `json:"port_bindings"`
-	Mounts       []mount.Mount `json:"mounts"`
+	// ExposedPorts is a slice of ports exposed by the docker container
+	ExposedPorts []string `json:"exposed_ports"`
+	// Env is a slice of environment variables to be set in the container, specified as KEY=VALUE
+	Env []string `json:"env"`
+	// PortBindings is a map of ports to bind on the host to ports in the container. Host IPs can be specified as well
+	PortBindings nat.PortMap `json:"port_bindings"`
+	// Mounts is a slice of mounts to be mounted in the container
+	Mounts []mount.Mount `json:"mounts"`
 }
 
 type AppDriver struct {

--- a/internal/node/processes/fx.go
+++ b/internal/node/processes/fx.go
@@ -21,6 +21,7 @@ func NewProcessManagerStateUpdateSubscriber(processManager ProcessManager, contr
 		[]hdb.IdempotentStateUpdateExecutor{
 			&StartProcessExecutor{
 				processManager: processManager,
+				nodeController: controller,
 			},
 		},
 		&ProcessRestorer{

--- a/internal/node/reverse_proxy/fx.go
+++ b/internal/node/reverse_proxy/fx.go
@@ -3,19 +3,22 @@ package reverse_proxy
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/constants"
+	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.uber.org/fx"
 )
 
-func NewProxyServer(lc fx.Lifecycle, logger *zerolog.Logger) (*ProxyServer, RuleSet) {
+func NewProxyServer(lc fx.Lifecycle, logger *zerolog.Logger, config *config.NodeConfig) (*ProxyServer, RuleSet) {
 	srv := &ProxyServer{
-		logger: logger,
-		Rules:  make(RuleSet),
+		logger:     logger,
+		Rules:      make(RuleSet),
+		nodeConfig: config,
 	}
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -31,10 +34,26 @@ func NewProxyServer(lc fx.Lifecycle, logger *zerolog.Logger) (*ProxyServer, Rule
 	return srv, srv.Rules
 }
 
+func NewProcessProxyRuleStateUpdateSubscriber(ruleSet RuleSet) (*hdb.IdempotentStateUpdateSubscriber, error) {
+	return hdb.NewIdempotentStateUpdateSubscriber(
+		"ProcessProxyRulesSubscriber",
+		node.SchemaName,
+		[]hdb.IdempotentStateUpdateExecutor{
+			&ProcessProxyRulesExecutor{
+				RuleSet: ruleSet,
+			},
+		},
+		&ReverseProxyRestorer{
+			ruleSet: ruleSet,
+		},
+	)
+}
+
 type ProxyServer struct {
-	logger *zerolog.Logger
-	server *http.Server
-	Rules  RuleSet
+	logger     *zerolog.Logger
+	server     *http.Server
+	nodeConfig *config.NodeConfig
+	Rules      RuleSet
 }
 
 func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -48,15 +67,20 @@ func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 }
 
-func (s *ProxyServer) Start(addr string) {
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		log.Fatal().Err(err).Msg("reverse proxy server failed to start")
-	}
+func (s *ProxyServer) Start(addr string) error {
 	httpServer := &http.Server{
 		Addr:    addr,
 		Handler: s,
 	}
+
+	tlsConfig, err := s.nodeConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+	httpServer.TLSConfig = tlsConfig
+
 	s.server = httpServer
-	log.Fatal().Err(httpServer.Serve(ln)).Msg("reverse proxy server failed")
+	err = httpServer.ListenAndServeTLS(s.nodeConfig.NodeCertPath(), s.nodeConfig.NodeKeyPath())
+	log.Fatal().Err(err).Msg("reverse proxy server failed")
+	return nil
 }

--- a/internal/node/reverse_proxy/fx.go
+++ b/internal/node/reverse_proxy/fx.go
@@ -24,7 +24,10 @@ func NewProxyServer(lc fx.Lifecycle, logger *zerolog.Logger, config *config.Node
 		OnStart: func(ctx context.Context) error {
 			listenAddr := fmt.Sprintf(":%s", constants.DefaultPortReverseProxy)
 			logger.Info().Msgf("Starting Habitat reverse proxy server at %s", listenAddr)
-			go srv.Start(listenAddr)
+			go func() {
+				err := srv.Start(listenAddr)
+				log.Fatal().Err(err).Msg("reverse proxy server failed")
+			}()
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {

--- a/internal/node/reverse_proxy/proxy.go
+++ b/internal/node/reverse_proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -110,7 +111,8 @@ func (r *RedirectRule) Handler() http.Handler {
 		Director: func(req *http.Request) {
 			req.URL.Scheme = r.ForwardLocation.Scheme
 			req.URL.Host = target
-			req.URL.Path = strings.TrimPrefix(req.URL.Path, r.Matcher) // TODO this needs to be fixed when globs are implemented
+			// TODO implement globs
+			req.URL.Path = path.Join(r.ForwardLocation.Path, strings.TrimPrefix(req.URL.Path, r.Matcher))
 		},
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{

--- a/internal/node/reverse_proxy/proxy.go
+++ b/internal/node/reverse_proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/rs/zerolog/log"
 )
 
@@ -19,6 +20,25 @@ func (r RuleSet) Add(name string, rule RuleHandler) error {
 		return fmt.Errorf("rule name %s is already taken", name)
 	}
 	r[name] = rule
+	return nil
+}
+
+func (r RuleSet) AddRule(rule *node.ReverseProxyRule) error {
+	if rule.Type == ProxyRuleRedirect {
+		url, err := url.Parse(rule.Target)
+		if err != nil {
+			return err
+		}
+		r.Add(rule.ID, &RedirectRule{
+			Matcher:         rule.Matcher,
+			ForwardLocation: url,
+		})
+	} else if rule.Type == ProxyRuleFileServer {
+		r.Add(rule.ID, &FileServerRule{
+			Matcher: rule.Matcher,
+			Path:    rule.Target,
+		})
+	}
 	return nil
 }
 

--- a/internal/node/reverse_proxy/proxy_test.go
+++ b/internal/node/reverse_proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,4 +115,39 @@ func TestProxy(t *testing.T) {
 	assert.NotNil(t, err)
 
 	assert.Equal(t, 1, len(proxy.Rules))
+}
+
+func TestAddRule(t *testing.T) {
+	proxy := &ProxyServer{
+		Rules: make(RuleSet),
+	}
+
+	err := proxy.Rules.AddRule(&node.ReverseProxyRule{
+		ID:      "backend1",
+		Type:    "redirect",
+		Matcher: "/backend1",
+		Target:  "http://localhost:8080",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(proxy.Rules))
+	assert.Equal(t, ProxyRuleRedirect, proxy.Rules["backend1"].Type())
+
+	err = proxy.Rules.AddRule(&node.ReverseProxyRule{
+		ID:      "backend2",
+		Type:    "file",
+		Matcher: "/backend2",
+		Target:  "http://localhost:8080",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(proxy.Rules))
+	assert.Equal(t, ProxyRuleFileServer, proxy.Rules["backend2"].Type())
+
+	// Test unknown rule
+	err = proxy.Rules.AddRule(&node.ReverseProxyRule{
+		ID:      "backend3",
+		Type:    "unknown",
+		Matcher: "/backend3",
+		Target:  "http://localhost:8080",
+	})
+	assert.NotNil(t, err)
 }

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -29,7 +29,7 @@ func (r *ReverseProxyRestorer) Restore(restoreEvent *hdb.StateUpdate) error {
 			log.Info().Msgf("Restoring rule %s", rule)
 			err = r.ruleSet.AddRule(rule)
 			if err != nil {
-				return err
+				log.Error().Msgf("error restoring rule: %s", err)
 			}
 		}
 	}

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -1,0 +1,37 @@
+package reverse_proxy
+
+import (
+	"encoding/json"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/node/hdb"
+	"github.com/rs/zerolog/log"
+)
+
+type ReverseProxyRestorer struct {
+	ruleSet RuleSet
+}
+
+func (r *ReverseProxyRestorer) Restore(restoreEvent *hdb.StateUpdate) error {
+	var nodeState node.NodeState
+	err := json.Unmarshal(restoreEvent.NewState, &nodeState)
+	if err != nil {
+		return err
+	}
+
+	for _, process := range nodeState.Processes {
+		rules, err := nodeState.GetReverseProxyRulesForProcess(process.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, rule := range rules {
+			log.Info().Msgf("Restoring rule %s", rule)
+			err = r.ruleSet.AddRule(rule)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/node/reverse_proxy/restore_test.go
+++ b/internal/node/reverse_proxy/restore_test.go
@@ -1,0 +1,74 @@
+package reverse_proxy
+
+import (
+	"testing"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/core/state/node/test_helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessRestorer(t *testing.T) {
+	ruleSet := make(RuleSet)
+
+	restorer := &ReverseProxyRestorer{
+		ruleSet: ruleSet,
+	}
+
+	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.NodeState{
+		Users: map[string]*node.User{
+			"user1": {
+				ID: "user1",
+			},
+		},
+		AppInstallations: map[string]*node.AppInstallationState{
+			"app1": {
+				AppInstallation: &node.AppInstallation{
+					ID:   "app1",
+					Name: "appname1",
+					Package: node.Package{
+						Driver: "test",
+					},
+				},
+			},
+		},
+		Processes: map[string]*node.ProcessState{
+			"proc1": {
+				Process: &node.Process{
+					ID:    "proc1",
+					AppID: "app1",
+				},
+				State: node.ProcessStateRunning,
+			},
+		},
+		ReverseProxyRules: &map[string]*node.ReverseProxyRule{
+			"rule1": {
+				ID:      "rule1",
+				AppID:   "app1",
+				Type:    "redirect",
+				Matcher: "/path",
+				Target:  "http://localhost:8080",
+			},
+			"brokenrule": {
+				ID:      "rule1",
+				AppID:   "app1",
+				Type:    "unknown",
+				Matcher: "/path",
+				Target:  "http://localhost:8080",
+			},
+			"rule2": {
+				ID:      "rule2",
+				AppID:   "app2",
+				Type:    "redirect",
+				Matcher: "/path2",
+				Target:  "http://localhost:8080",
+			},
+		},
+	})
+	assert.Nil(t, err)
+
+	err = restorer.Restore(restoreUpdate)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 1, len(restorer.ruleSet))
+}

--- a/internal/node/reverse_proxy/rules.go
+++ b/internal/node/reverse_proxy/rules.go
@@ -6,9 +6,3 @@ const (
 	ProxyRuleFileServer = "file"
 	ProxyRuleRedirect   = "redirect"
 )
-
-type ProxyRule struct {
-	Type    string `yaml:"type"`
-	Matcher string `yaml:"matcher"`
-	Target  string `yaml:"target"`
-}

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -1,0 +1,55 @@
+package reverse_proxy
+
+import (
+	"encoding/json"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/node/hdb"
+	"github.com/rs/zerolog/log"
+)
+
+type ProcessProxyRulesExecutor struct {
+	RuleSet RuleSet
+}
+
+func (e *ProcessProxyRulesExecutor) TransitionType() string {
+	return node.TransitionStartProcess
+}
+
+func (e *ProcessProxyRulesExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, error) {
+	// This process is very lightweight, so we can just execute it every time
+	return true, nil
+}
+
+func (e *ProcessProxyRulesExecutor) Execute(update *hdb.StateUpdate) error {
+	var processStartTransition node.ProcessStartTransition
+	err := json.Unmarshal(update.Transition, &processStartTransition)
+	if err != nil {
+		return err
+	}
+
+	// Get the node state
+	var state node.NodeState
+	err = json.Unmarshal(update.NewState, &state)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range *state.ReverseProxyRules {
+		if rule.AppID == processStartTransition.AppID {
+			log.Info().Msgf("Adding reverse proxy rule %v", rule)
+			err = e.RuleSet.AddRule(rule)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// TODO remove rule when process is stopped
+
+func (e *ProcessProxyRulesExecutor) PostHook(update *hdb.StateUpdate) error {
+	return nil
+}

--- a/internal/node/reverse_proxy/subscriber_test.go
+++ b/internal/node/reverse_proxy/subscriber_test.go
@@ -1,0 +1,117 @@
+package reverse_proxy
+
+import (
+	"testing"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/core/state/node/test_helpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscriber(t *testing.T) {
+	executor := &ProcessProxyRulesExecutor{
+		RuleSet: make(RuleSet),
+	}
+
+	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
+		Process: &node.Process{
+			ID:     "proc1",
+			Driver: "test",
+			AppID:  "app1",
+		},
+		App: &node.AppInstallation{
+			ID:   "app1",
+			Name: "appname1",
+			Package: node.Package{
+				Driver: "test",
+			},
+		},
+	}, &node.NodeState{
+		AppInstallations: map[string]*node.AppInstallationState{
+			"app1": {
+				AppInstallation: &node.AppInstallation{
+					ID:   "app1",
+					Name: "appname1",
+					Package: node.Package{
+						Driver: "test",
+					},
+				},
+			},
+		},
+		ReverseProxyRules: &map[string]*node.ReverseProxyRule{
+			"rule1": {
+				ID:      "rule1",
+				AppID:   "app1",
+				Type:    "redirect",
+				Matcher: "/path",
+				Target:  "http://localhost:8080",
+			},
+			"rule2": {
+				ID:      "rule2",
+				AppID:   "app2",
+				Type:    "redirect",
+				Matcher: "/path2",
+				Target:  "http://localhost:8080",
+			},
+		},
+		Processes: map[string]*node.ProcessState{},
+	})
+	assert.Nil(t, err)
+
+	shouldExecute, err := executor.ShouldExecute(startProcessStateUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, true, shouldExecute)
+	assert.Equal(t, 0, len(executor.RuleSet))
+
+	err = executor.Execute(startProcessStateUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(executor.RuleSet))
+}
+
+func TestBrokenRule(t *testing.T) {
+	executor := &ProcessProxyRulesExecutor{
+		RuleSet: make(RuleSet),
+	}
+
+	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
+		Process: &node.Process{
+			ID:     "proc1",
+			Driver: "test",
+			AppID:  "app1",
+		},
+		App: &node.AppInstallation{
+			ID:   "app1",
+			Name: "appname1",
+			Package: node.Package{
+				Driver: "test",
+			},
+		},
+	}, &node.NodeState{
+		AppInstallations: map[string]*node.AppInstallationState{
+			"app1": {
+				AppInstallation: &node.AppInstallation{
+					ID:   "app1",
+					Name: "appname1",
+					Package: node.Package{
+						Driver: "test",
+					},
+				},
+			},
+		},
+		ReverseProxyRules: &map[string]*node.ReverseProxyRule{
+			"brokenrule": {
+				ID:      "rule1",
+				AppID:   "app1",
+				Type:    "unknown",
+				Matcher: "/path",
+				Target:  "http://localhost:8080",
+			},
+		},
+		Processes: map[string]*node.ProcessState{},
+	})
+	assert.Nil(t, err)
+
+	err = executor.Execute(startProcessStateUpdate)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(executor.RuleSet))
+}


### PR DESCRIPTION
This PR prepares Habitat to support running an [ATProto Personal Data Server](https://github.com/bluesky-social/pds). However, this PR does not have anything specifically related to the PDS application. Instead, this PR contains a bunch of improvements needed to run the PDS server in a subsequent PR.

New additions:
- Each app installation has a `driver_config` field, which configures that app's installation based off of which app driver it uses.
- Installing applications also sets up reverse proxy rules that will be used when the app is started. This lets us forward traffic to the PDS's `xrpc` endpoint from the Habitat API proxy url at `localhost:3001`
- Reverse proxy now does TLS termination
- Create a helper for generating the initial state of a node by migrating an empty state from version `v0.0.1` to the latest version. This future proofs our initial state code (e.g. avoid having an empty map for a field that shouldn't exist in the current version, rather than `nil`).
- Some bug fixes

This has already been tested with the ATProto PDS, there is just no reference to it in this PR yet. If you want to try it with the PDS, hit `https://localhost:3000/users/0/apps` with this body (make sure to change any local paths):
```
{
    "app_installation": {
        "name": "pds",
        "version": "1",
        "driver": "docker",
        "driver_config": {
            "env": [
                "PDS_DATA_DIRECTORY=/pds",
                "PDS_BLOBSTORE_DISK_LOCATION=/pds/blocks",
                "PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=5290bb1866a03fb23b09a6ffd64d21f6a4ebf624eaa301930eeb81740699239c",
                "PDS_JWT_SECRET=bd6df801372d7058e1ce472305d7fc2e",
                "PDS_ADMIN_PASSWORD=password"
            ],
            "mounts": [
                {
                    "Type": "bind",
                    "Source": "/Users/ethan/code/habitat/habitat-new/.habitat/pds",
                    "Target": "/pds"
                }
            ],
            "exposed_ports": [ "5000" ],
            "port_bindings": {
                "3000/tcp": [
                    {
                        "hostIp": "127.0.0.1",
                        "hostPort": "5000"
                    }
                ]
            }
        },
        "registry_url_base": "registry.hub.docker.com",
        "registry_app_id": "ethangraf/pds",
        "registry_tag": "latest"
    },
    "reverse_proxy_rules": [
        {
            "type": "redirect",
            "matcher": "/xrpc",
            "target": "http://host.docker.internal:5000/xrpc"
        }
    ]
}
```
