### PR TITLE
Tailscale fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ docker-build:
 	docker build -t habitat_node -f ./build/node.dev.Dockerfile .
 
 run-dev:
-	TOPDIR=$(TOPDIR) DOCKER_WORKDIR=$(DOCKER_WORKDIR) DEV_HABITAT_PATH=$(DEV_HABITAT_PATH) docker-compose -f ./build/compose.yml up
+	TOPDIR=$(TOPDIR) DOCKER_WORKDIR=$(DOCKER_WORKDIR) DEV_HABITAT_PATH=$(DEV_HABITAT_PATH) TS_AUTHKEY=$(origin TS_AUTHKEY) docker-compose -f ./build/compose.yml up
 
 clear-volumes:
 	docker container rm -f habitat_node || true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make run-dev-compose          # Runs the habitat node in dev mode
 ```
 To get added to the Tailscale tailnet the first time you run Habitat in dev mode, get an auth key issued from Tailscale and run. You only need to do this once, unless you remove the volumes in `.habitat`.
 ```
-TAILSCALE_AUTHKEY=<authkey> make run-dev-compose
+TS_AUTHKEY=<authkey> make run-dev-compose
 ```
 The container saves node state in an anonymous volume. If you'd like to run the Habitat node with completely new state, run:
 ```

--- a/build/compose.yml
+++ b/build/compose.yml
@@ -18,6 +18,7 @@ services:
       - TS_STATE_DIR=/etc/ts-state/
       - TS_TAILNET=habitat.ts.test@gmail.com
       - TS_EXTRA_ARGS=--advertise-tags=tag:habitat-node-dev
+      - TS_AUTHKEY=${TS_AUTHKEY}
   habitat_node:
     volumes:
         - ${TOPDIR}/core:${DOCKER_WORKDIR}/core

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -24,12 +24,12 @@ func loadEnv() error {
 	}
 	viper.SetDefault("habitat_path", filepath.Join(homedir, ".habitat"))
 
-	err = viper.BindEnv("tailscale_authkey", "TAILSCALE_AUTHKEY")
+	err = viper.BindEnv("tailscale_authkey", "TS_AUTHKEY")
 	if err != nil {
 		return err
 	}
 
-	err = viper.BindEnv("tailnet", "TAILSCALE_TAILNET")
+	err = viper.BindEnv("tailnet", "TS_TAILNET")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Small bug fixes that Ethan ran into when restarting Habitat with tailscale.
- actually use the `TS_AUTHKEY` env var from command line
- rename `TAILSCALE_` to `TS_` since that's what tailscale looks for