### PR TITLE
Switch to standard lib ServeMux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/google/uuid v1.5.0
-	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/raft v1.6.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20231211162105-6c830fa4535e
 	github.com/qri-io/jsonschema v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/node/api/server.go
+++ b/internal/node/api/server.go
@@ -8,13 +8,17 @@ import (
 	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/constants"
 	"github.com/eagraf/habitat-new/internal/node/reverse_proxy"
-	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 )
 
 const CertificateDir = "/dev_certificates"
 
-func NewAPIServer(router *mux.Router, logger *zerolog.Logger, proxyRules reverse_proxy.RuleSet, nodeConfig *config.NodeConfig) (*http.Server, error) {
+func NewAPIServer(
+	router http.Handler,
+	logger *zerolog.Logger,
+	proxyRules reverse_proxy.RuleSet,
+	nodeConfig *config.NodeConfig,
+) (*http.Server, error) {
 	srv := &http.Server{Addr: fmt.Sprintf(":%s", constants.DefaultPortHabitatAPI), Handler: router}
 	tlsConfig, err := nodeConfig.TLSConfig()
 	if err != nil {

--- a/internal/node/controller/routes.go
+++ b/internal/node/controller/routes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/constants"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
-	"github.com/gorilla/mux"
 	"golang.org/x/mod/semver"
 )
 
@@ -86,8 +85,7 @@ func (h *InstallAppRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vars := mux.Vars(r)
-	userID := vars["user_id"]
+	userID := r.PathValue("user_id")
 
 	var req types.PostAppRequest
 	err := json.NewDecoder(r.Body).Decode(&req)

--- a/internal/node/controller/routes.go
+++ b/internal/node/controller/routes.go
@@ -32,11 +32,6 @@ func (h *MigrationRoute) Method() string {
 }
 
 func (h *MigrationRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "invalid method, require POST", http.StatusMethodNotAllowed)
-		return
-	}
-
 	var req types.MigrateRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -80,11 +75,6 @@ func (h *InstallAppRoute) Method() string {
 }
 
 func (h *InstallAppRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "invalid method, require POST", http.StatusMethodNotAllowed)
-		return
-	}
-
 	userID := r.PathValue("user_id")
 
 	var req types.PostAppRequest
@@ -128,11 +118,6 @@ func (h *StartProcessHandler) Method() string {
 }
 
 func (h *StartProcessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "invalid method, require POST", http.StatusMethodNotAllowed)
-		return
-	}
-
 	var req types.PostProcessRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -232,11 +217,6 @@ func (h *AddUserRoute) Method() string {
 }
 
 func (h *AddUserRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "invalid method, require POST", http.StatusMethodNotAllowed)
-		return
-	}
-
 	var req types.PostAddUserRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {

--- a/internal/node/controller/routes_test.go
+++ b/internal/node/controller/routes_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +16,6 @@ import (
 	"github.com/eagraf/habitat-new/internal/node/controller/mocks"
 	hdb_mocks "github.com/eagraf/habitat-new/internal/node/hdb/mocks"
 	"github.com/google/uuid"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -29,46 +27,41 @@ func TestMigrations(t *testing.T) {
 	m := mocks.NewMockNodeController(ctrl)
 	handler := NewMigrationRoute(m)
 
-	router := mux.NewRouter()
-	router.Handle(handler.Pattern(), handler).Methods(handler.Method())
-	server := httptest.NewServer(router)
-
-	body := &types.MigrateRequest{
+	b, err := json.Marshal(types.MigrateRequest{
 		TargetVersion: "v0.0.2",
-	}
-
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		t.Error(err)
-	}
-
-	client := server.Client()
-	url := fmt.Sprintf("%s%s", server.URL, handler.Pattern())
+	})
+	require.NoError(t, err)
 
 	m.EXPECT().MigrateNodeDB("v0.0.2").Return(nil).Times(1)
-
-	resp, err := client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
 
 	// Test error from node controller
 	m.EXPECT().MigrateNodeDB("v0.0.2").Return(errors.New("invalid version")).Times(1)
-
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	// Test invalid semver
-	body.TargetVersion = "invalid"
-	bodyBytes, err = json.Marshal(body)
-	if err != nil {
-		t.Error(err)
-	}
+	b, err = json.Marshal(types.MigrateRequest{
+		TargetVersion: "invalid",
+	})
+	require.NoError(t, err)
 
-	m.EXPECT().MigrateNodeDB("invalid").Times(0)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	m.EXPECT().MigrateNodeDB(gomock.Any()).Times(0)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	assert.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
 
 }
 
@@ -78,11 +71,6 @@ func TestInstallAppHandler(t *testing.T) {
 	m := mocks.NewMockNodeController(ctrl)
 
 	handler := NewInstallAppRoute(m)
-
-	router := mux.NewRouter()
-	router.Handle(handler.Pattern(), handler).Methods(handler.Method())
-
-	server := httptest.NewServer(router)
 
 	body := &types.PostAppRequest{
 		AppInstallation: &node.AppInstallation{
@@ -98,38 +86,45 @@ func TestInstallAppHandler(t *testing.T) {
 		ReverseProxyRules: []*node.ReverseProxyRule{},
 	}
 
-	bodyBytes, err := json.Marshal(body)
-	if err != nil {
-		t.Error(err)
-	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
 
 	testAppInstallation := body.AppInstallation
 	testAppInstallation.UserID = "0"
 	m.EXPECT().InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).Return(nil).Times(1)
 
-	client := server.Client()
-	url := fmt.Sprintf("%s/node/users/0/apps", server.URL)
-
 	// Test the happy path
-	resp, err := client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusCreated, resp.Result().StatusCode)
 
-	respBody, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(respBody))
+	respBody, err := io.ReadAll(resp.Result().Body)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(respBody))
 
 	// Test an error returned by the controller
-	m.EXPECT().InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).Return(errors.New("Couldn't install app")).Times(1)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	m.EXPECT().
+		InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).
+		Return(errors.New("Couldn't install app")).
+		Times(1)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	// Test invalid request
 	m.EXPECT().StartProcess(body.AppInstallation).Times(0)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer([]byte("invalid")))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader([]byte("invalid"))),
+	)
+	assert.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
 }
 
 func TestStartProcessHandler(t *testing.T) {
@@ -137,20 +132,13 @@ func TestStartProcessHandler(t *testing.T) {
 
 	m := mocks.NewMockNodeController(ctrl)
 
-	handler := NewStartProcessHandler(m)
-
-	router := mux.NewRouter()
 	middleware := &test_helpers.TestAuthMiddleware{UserID: "user_1"}
-	router.Use(middleware.Middleware)
-	router.Handle(handler.Pattern(), handler).Methods(handler.Method())
+	startProcessHandler := NewStartProcessHandler(m)
+	handler := middleware.Middleware(startProcessHandler)
 
-	server := httptest.NewServer(router)
-
-	body := &types.PostProcessRequest{
+	b, err := json.Marshal(types.PostProcessRequest{
 		AppInstallationID: "app_1",
-	}
-
-	bodyBytes, err := json.Marshal(body)
+	})
 	if err != nil {
 		t.Error(err)
 	}
@@ -173,17 +161,17 @@ func TestStartProcessHandler(t *testing.T) {
 		return nil
 	}).Times(1)
 
-	client := server.Client()
-	url := fmt.Sprintf("%s/node/processes", server.URL)
-
 	// Test the happy path
-	resp, err := client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, startProcessHandler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusCreated, resp.Result().StatusCode)
 
-	respBody, err := io.ReadAll(resp.Body)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(respBody))
+	respBody, err := io.ReadAll(resp.Result().Body)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(respBody))
 
 	// Test an error returned by the controller
 	m.EXPECT().GetAppByID("app_1").Return(&node.AppInstallation{
@@ -191,19 +179,26 @@ func TestStartProcessHandler(t *testing.T) {
 		Package: node.Package{Driver: "docker"},
 	}, nil).Times(1)
 	m.EXPECT().StartProcess(gomock.Any()).Return(errors.New("Couldn't install app")).Times(1)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer(bodyBytes))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, startProcessHandler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	// Test invalid request
-	m.EXPECT().GetAppByID("app_1").Return(&node.AppInstallation{
-		ID:      "app_1",
-		Package: node.Package{Driver: "docker"},
-	}, nil).Times(0)
+	m.EXPECT().GetAppByID(gomock.Any()).Times(0)
 	m.EXPECT().StartProcess(gomock.Any()).Times(0)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer([]byte("invalid")))
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(
+			http.MethodPost,
+			startProcessHandler.Pattern(),
+			bytes.NewReader([]byte("invalid")),
+		),
+	)
+	assert.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
 }
 
 func TestGetNodeHandler(t *testing.T) {
@@ -224,27 +219,19 @@ func TestGetNodeHandler(t *testing.T) {
 
 	mockDB.EXPECT().GetDatabaseClientByName(constants.NodeDBDefaultName).Return(mockClient, nil)
 	mockClient.EXPECT().Bytes().Return(bytes)
-	id := uuid.New().String()
-	mockClient.EXPECT().DatabaseID().Return(id)
+	mockClient.EXPECT().DatabaseID().Return(uuid.New().String())
 
 	handler := NewGetNodeRoute(mockDB)
 
-	router := mux.NewRouter()
-	router.Handle(handler.Pattern(), handler).Methods(handler.Method())
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, handler.Pattern(), nil))
+	require.Equal(t, http.StatusOK, resp.Result().StatusCode)
 
-	server := httptest.NewServer(router)
-	client := server.Client()
-	url := fmt.Sprintf("%s%s", server.URL, handler.Pattern())
-
-	resp, err := client.Get(url)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	bytes, err = io.ReadAll(resp.Body)
-	require.Nil(t, err)
+	bytes, err = io.ReadAll(resp.Result().Body)
+	require.NoError(t, err)
 
 	var respBody types.GetNodeResponse
-	require.Nil(t, json.Unmarshal(bytes, &respBody))
+	require.NoError(t, json.Unmarshal(bytes, &respBody))
 	for k, v := range respBody.State {
 		v2, ok := testState[k]
 		require.True(t, ok)
@@ -259,37 +246,36 @@ func TestAddUserHandler(t *testing.T) {
 	m := mocks.NewMockNodeController(ctrl)
 	handler := NewAddUserRoute(m)
 
-	router := mux.NewRouter()
-	router.Handle(handler.Pattern(), handler).Methods(handler.Method())
-
-	server := httptest.NewServer(router)
-	client := server.Client()
-	url := fmt.Sprintf("%s%s", server.URL, handler.Pattern())
-
-	body := &types.PostAddUserRequest{
+	b, err := json.Marshal(&types.PostAddUserRequest{
 		UserID:      "myUserID",
 		Username:    "myUsername",
 		Certificate: "myCert",
-	}
-	b, err := json.Marshal(body)
-	require.Nil(t, err)
+	})
+	require.NoError(t, err)
 
 	m.EXPECT().AddUser("myUserID", "myUsername", "myCert").Return(nil)
-
-	resp, err := client.Post(url, "application/json", bytes.NewBuffer(b))
-	require.Nil(t, err)
-	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusCreated, resp.Result().StatusCode)
 
 	// Test internal server error
 	m.EXPECT().AddUser("myUserID", "myUsername", "myCert").Return(errors.New("error adding user"))
-
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer(b))
-	require.Nil(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+	)
+	require.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	// Test invalid request
 	m.EXPECT().AddUser("myUserID", "myUsername", "myCert").Times(0)
-	resp, err = client.Post(url, "application/json", bytes.NewBuffer([]byte("invalid")))
-	require.Nil(t, err)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(
+		resp,
+		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader([]byte("invalid"))),
+	)
+	require.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
 }

--- a/internal/node/controller/routes_test.go
+++ b/internal/node/controller/routes_test.go
@@ -94,10 +94,12 @@ func TestInstallAppHandler(t *testing.T) {
 	m.EXPECT().InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).Return(nil).Times(1)
 
 	// Test the happy path
+	req := httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b))
+	req.SetPathValue("user_id", "0")
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(
 		resp,
-		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+		req,
 	)
 	require.Equal(t, http.StatusCreated, resp.Result().StatusCode)
 
@@ -110,10 +112,12 @@ func TestInstallAppHandler(t *testing.T) {
 		InstallApp("0", testAppInstallation, []*node.ReverseProxyRule{}).
 		Return(errors.New("Couldn't install app")).
 		Times(1)
+	req = httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b))
+	req.SetPathValue("user_id", "0")
 	resp = httptest.NewRecorder()
 	handler.ServeHTTP(
 		resp,
-		httptest.NewRequest(http.MethodPost, handler.Pattern(), bytes.NewReader(b)),
+		req,
 	)
 	require.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 


### PR DESCRIPTION
Removes unnecessary dependency + makes it easier to implement serving static directory for FE. 

Also refactored the handlers tests to directly call the handler instead of setting up a server to route the requests to better isolate. 