### PR TITLE
Upgrade Go v1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Get dependencies
       run: |

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -30,3 +30,9 @@ exclude:
     - \/fx\.go$
     - \/test_helpers
     - ^pkg\/raft\/transport
+    - ^pkg\/raft\/transport
+    - ^internal/node/docker
+    - ^internal/node/api
+    - ^cmd/node
+    - ^internal/node/reverse_proxy/server.go
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eagraf/habitat-new
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v25.0.1+incompatible

--- a/internal/node/reverse_proxy/proxy_test.go
+++ b/internal/node/reverse_proxy/proxy_test.go
@@ -19,9 +19,11 @@ import (
 
 func TestProxy(t *testing.T) {
 	// Simulate a server sitting behind the reverse proxy
-	redirectedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello, World!")
-	}))
+	redirectedServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "Hello, World!")
+		}),
+	)
 	defer redirectedServer.Close()
 
 	redirectedServerURL, err := url.Parse(redirectedServer.URL)
@@ -63,7 +65,7 @@ func TestProxy(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 2, len(proxy.Rules))
 
-	close, err := proxy.Start("127.0.0.1:9898", nil)
+	close, err := proxy.Start("localhost:9898", nil)
 	require.Nil(t, err)
 	defer close()
 


### PR DESCRIPTION
Prompted by https://github.com/eagraf/habitat-new/pull/14 where we need `http.Request.PathValue` which was added in 1.22