### PR TITLE
Implement router based modal

### DIFF
--- a/frontend/app/@modal/add-app/page.tsx
+++ b/frontend/app/@modal/add-app/page.tsx
@@ -1,0 +1,3 @@
+export default function AddAppModal() {
+  return <div>Test modal</div>
+}

--- a/frontend/app/@modal/default.tsx
+++ b/frontend/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null
+}

--- a/frontend/app/@modal/page.tsx
+++ b/frontend/app/@modal/page.tsx
@@ -1,0 +1,3 @@
+export default function ModalIndex() {
+  return null
+}

--- a/frontend/app/default.tsx
+++ b/frontend/app/default.tsx
@@ -1,3 +1,5 @@
+import Home from "./page";
+
 export default function Default() {
-  return null;
+  return <Home />;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import Providers from '@/components/Providers'
 import Version from '@/components/Version'
 import Link from 'next/link'
+import Modal from '@/components/Modal'
 
 export const metadata: Metadata = {
   title: 'Habitat',
@@ -11,8 +12,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: {
   children: React.ReactNode
+  modal: React.ReactNode
 }) {
   return (
     <html lang="en">
@@ -26,6 +29,7 @@ export default function RootLayout({
             <Version />
           </header>
           {children}
+          <Modal>{modal}</Modal>
         </body>
       </Providers>
     </html>

--- a/frontend/components/AppsCard.tsx
+++ b/frontend/components/AppsCard.tsx
@@ -1,7 +1,9 @@
 "use client"
 import useNode, { Node } from "@/hooks/useNode"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "./ui/button";
+import Link from "next/link";
 
 function selectApps(node: Node) {
   return Object.values(node.state.app_installations)
@@ -42,6 +44,11 @@ export default function AppsCard({ className }: AppsCardProps) {
           </TableBody>
         )}
       </Table>
+      <CardFooter>
+        <Link href="/add-app" className="ml-auto" scroll={false}>
+          <Button>Add</Button>
+        </Link>
+      </CardFooter>
     </Card>
   )
 }

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { usePreviousRoute } from "@/components/PreviousRouteContext";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useRouter, useSelectedLayoutSegment, useSelectedLayoutSegments } from "next/navigation";
+import { PropsWithChildren, useEffect, useState } from "react";
+
+export default function Modal({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false)
+  const modalSegment = useSelectedLayoutSegment('modal')
+  const router = useRouter()
+  const previousRoute = usePreviousRoute()
+  const topSegments = useSelectedLayoutSegments()
+
+  useEffect(() => {
+    setOpen(!!modalSegment)
+  }, [modalSegment])
+
+  return <Dialog open={open} onOpenChange={(open) => {
+    if (!open) {
+      if (previousRoute) {
+        router.back()
+      } else {
+        router.replace("/" + topSegments.slice(0, -1).join("/"))
+      }
+    }
+  }}>
+    <DialogContent>{children}</DialogContent>
+  </Dialog>;
+}

--- a/frontend/components/PreviousRouteContext.tsx
+++ b/frontend/components/PreviousRouteContext.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { PropsWithChildren, createContext, useContext, useEffect, useState } from "react"
+
+const PreviousRouteGetterContext = createContext<string | undefined>(undefined)
+
+export function usePreviousRoute() {
+  return useContext(PreviousRouteGetterContext)
+}
+
+export function PreviousRouteProvider({ children }: PropsWithChildren) {
+  const pathname = usePathname()
+  const [currentRoute, setCurrentRoute] = useState<string | undefined>(undefined)
+  const [prevRoute, setPreviousRoute] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    setPreviousRoute(currentRoute)
+    setCurrentRoute(pathname)
+  }, [pathname])
+  return <PreviousRouteGetterContext.Provider value={prevRoute}>
+    {children}
+  </PreviousRouteGetterContext.Provider>
+}

--- a/frontend/components/Providers.tsx
+++ b/frontend/components/Providers.tsx
@@ -2,13 +2,16 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren } from "react";
+import { PreviousRouteProvider } from "./PreviousRouteContext";
 
 const queryClient = new QueryClient()
 
 export default function Providers({ children }: PropsWithChildren) {
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <PreviousRouteProvider>
+        {children}
+      </PreviousRouteProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/components/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/components/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}


### PR DESCRIPTION
We can add modals to the FE by placing a route under the `@modal` dir using [parallel routes](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes). Added some logic to use browser history to close the modal to not clutter the stack.