### PR TITLE
Deployment fixes and embed frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       with:
         go-version: 1.22
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 22
+
     - name: Get dependencies
       run: |
         go get -v -t -d ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
       run: |
         go get -v -t -d ./...
 
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v4.0.0
-
     - name: Build
       run: make build
 
     - name: Docker Build
       run: make docker-build
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v4.0.0
 
     - name: Test
       run: go test ./... -coverprofile=coverage.out -coverpkg=./...

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin/
 
 # Developer specific environment
 dev.env
+
+# Ignore frontend build
+internal/frontend/build

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -36,3 +36,4 @@ exclude:
     - ^cmd/node
     - ^internal/node/reverse_proxy/server.go
     - ^internal/node/server/server.go
+    - ^internal/frontend

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,6 @@ $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz: $(TOPDIR)/bin/amd64-darw
 
 # Embed the frontend in the binary
 internal/frontend/build:
-	cd $(TOPDIR)/frontend && npm run build
+	cd $(TOPDIR)/frontend && npm install && npm run build
 	mkdir -p $(TOPDIR)/internal/frontend/build
 	cp -r $(TOPDIR)/frontend/out/* $(TOPDIR)/internal/frontend/build

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ clean::
 	rm -rf $(TOPDIR)/bin
 	rm -rf $(TOPDIR)/internal/frontend/build
 	rm -rf $(TOPDIR)/frontend/out
+	rm -rf $(TOPDIR)/frontend/.next
 
 test-coverage:
 	go test ./... -coverprofile=coverage.out -coverpkg=./... -timeout 1s
@@ -115,5 +116,5 @@ $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz: $(TOPDIR)/bin/amd64-darw
 # Embed the frontend in the binary
 internal/frontend/build:
 	cd $(TOPDIR)/frontend && npm run build
-	mkdir -p $(TOPDIR)/internal/node/frontend/build
+	mkdir -p $(TOPDIR)/internal/frontend/build
 	cp -r $(TOPDIR)/frontend/out/* $(TOPDIR)/internal/frontend/build

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ archive: $(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz $(TOPDIR)/bin/amd6
 test::
 	go test ./... -timeout 1s
 
+clean::
+	rm -rf $(TOPDIR)/bin
+	rm -rf $(TOPDIR)/internal/frontend/build
+	rm -rf $(TOPDIR)/frontend/out
+
 test-coverage:
 	go test ./... -coverprofile=coverage.out -coverpkg=./... -timeout 1s
 	${GOBIN}/go-test-coverage --config=./.testcoverage.yml || true
@@ -93,15 +98,22 @@ $(TOPDIR)/bin: $(TOPDIR)
 	mkdir -p $(TOPDIR)/bin
 
 # Linux AMD64 Builds
-$(TOPDIR)/bin/amd64-linux/habitat: $(TOPDIR)/bin
+$(TOPDIR)/bin/amd64-linux/habitat: $(TOPDIR)/bin internal/frontend/build
 	GOARCH=amd64 GOOS=linux go build -o $(TOPDIR)/bin/amd64-linux/habitat $(TOPDIR)/cmd/node/main.go
 
 $(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz: $(TOPDIR)/bin/amd64-linux/habitat
 	tar -czf $(TOPDIR)/bin/amd64-linux/habitat-amd64-linux.tar.gz -C $(TOPDIR)/bin/amd64-linux habitat
 
 # Darwin AMD64 Builds
-$(TOPDIR)/bin/amd64-darwin/habitat: $(TOPDIR)/bin
+$(TOPDIR)/bin/amd64-darwin/habitat: $(TOPDIR)/bin internal/frontend/build
 	GOARCH=amd64 GOOS=darwin go build -o $(TOPDIR)/bin/amd64-darwin/habitat $(TOPDIR)/cmd/node/main.go
 
 $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz: $(TOPDIR)/bin/amd64-darwin/habitat
 	tar -czf $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz -C $(TOPDIR)/bin/amd64-darwin habitat
+
+
+# Embed the frontend in the binary
+internal/frontend/build:
+	cd $(TOPDIR)/frontend && npm run build
+	mkdir -p $(TOPDIR)/internal/node/frontend/build
+	cp -r $(TOPDIR)/frontend/out/* $(TOPDIR)/internal/frontend/build

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Note: we know that doing this is insecure, but this is a quick way to bootstrap 
 
 The installer will ask you to generate some credentials. If you have done this before, you can skip this step. After finishing the installer, you can now run habitat like this:
 ```
-habitat
+~/.habitat/bin/habitat
 ```
 
 Currently, there is no way to run Habitat as a daemon, but this will be supported in the future.

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -161,7 +161,12 @@ func main() {
 		),
 	)
 
-	err = proxy.Rules.Add("Frontend", frontend.NewFrontendProxyRule(nodeConfig))
+	frontendProxyRule, err := frontend.NewFrontendProxyRule(nodeConfig)
+	if err != nil {
+		log.Fatal().Err(fmt.Errorf("error getting frontend proxy rule: %v", err))
+	}
+
+	err = proxy.Rules.Add("Frontend", frontendProxyRule)
 	if err != nil {
 		log.Fatal().Err(fmt.Errorf("error adding frontend proxy rule: %v", err))
 	}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -161,7 +161,7 @@ func main() {
 		),
 	)
 
-	err = proxy.Rules.Add("Frontend", frontend.NewFrontendProxyRule())
+	err = proxy.Rules.Add("Frontend", frontend.NewFrontendProxyRule(nodeConfig))
 	if err != nil {
 		log.Fatal().Err(fmt.Errorf("error adding frontend proxy rule: %v", err))
 	}

--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,11 @@ curl -L $ARCHIVE_URL -o $TMP_DIR/habitat-${ARCH}-${OS}.tar.gz
 mkdir -p $TMP_DIR/habitat-${ARCH}-${OS}
 tar -xzf $TMP_DIR/habitat-${ARCH}-${OS}.tar.gz -C $TMP_DIR/habitat-${ARCH}-${OS}
 
-cp $TMP_DIR/habitat-${ARCH}-${OS}/habitat /usr/local/bin/habitat
 
-mkdir -p $HOME/.habitat
+BIN_PATH="$HOME/.habitat/bin"
+mkdir -p $BIN_PATH
+
+cp $TMP_DIR/habitat-${ARCH}-${OS}/habitat $BIN_PATH/habitat
 
 CERT_DIR="$HOME/.habitat/certificates"
 mkdir -p "$CERT_DIR"

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,16 @@
 # We are doing this for convenience, but don't take this as a good example of how
 # to do things. You should always verify the contents of a script before executing it.
 
+# Usage:
+#
+# Use latest version:
+#
+#   curl -sL https://github.com/eagraf/habitat-new/releases/latest/download/install.sh 2>&1 | bash
+#
+# Use specific version:
+#
+#   curl -sL https://github.com/eagraf/habitat-new/releases/download/v0.0.2/install.sh 2>&1 | bash
+
 set -euxo pipefail
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,16 @@ if [ "$ARCH" == "x86_64" ]; then
     ARCH="amd64"
 fi
 
-ARCHIVE_URL="https://github.com/eagraf/habitat-new/releases/latest/download/habitat-${ARCH}-${OS}.tar.gz"
+VERSION="latest"
+if [ -n "$1" ]; then
+    VERSION=$1
+fi
+
+if [[ "$VERSION" == "latest" ]]; then
+    ARCHIVE_URL="https://github.com/eagraf/habitat-new/releases/latest/download/habitat-${ARCH}-${OS}.tar.gz"
+else
+    ARCHIVE_URL="https://github.com/eagraf/habitat-new/releases/download/${VERSION}/habitat-${ARCH}-${OS}.tar.gz"
+fi
 
 TMP_DIR=$(mktemp -d)
 echo "Downloading to $TMP_DIR"

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -3,13 +3,12 @@ package frontend
 import (
 	"net/url"
 
+	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/reverse_proxy"
-	"github.com/spf13/viper"
 )
 
-func NewFrontendProxyRule() reverse_proxy.RuleHandler {
-	viper.BindEnv("frontend_dev", "FRONTEND_DEV")
-	if viper.GetBool("frontend_dev") {
+func NewFrontendProxyRule(config *config.NodeConfig) reverse_proxy.RuleHandler {
+	if config.FrontendDev() {
 		feDevServer, _ := url.Parse("http://habitat_frontend:8000/")
 		return &reverse_proxy.RedirectRule{
 			Matcher:         "/",

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -1,23 +1,33 @@
 package frontend
 
 import (
+	"embed"
+	"io/fs"
 	"net/url"
 
 	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/reverse_proxy"
 )
 
-func NewFrontendProxyRule(config *config.NodeConfig) reverse_proxy.RuleHandler {
+//go:embed build/*
+var frontendBuild embed.FS
+
+func NewFrontendProxyRule(config *config.NodeConfig) (reverse_proxy.RuleHandler, error) {
 	if config.FrontendDev() {
 		feDevServer, _ := url.Parse("http://habitat_frontend:8000/")
 		return &reverse_proxy.RedirectRule{
 			Matcher:         "/",
 			ForwardLocation: feDevServer,
-		}
+		}, nil
 	} else {
+
+		fSys, err := fs.Sub(frontendBuild, "build")
+		if err != nil {
+			return nil, err
+		}
 		return &reverse_proxy.FileServerRule{
 			Matcher: "/",
-			Path:    "frontend/out",
-		}
+			FS:      fSys,
+		}, nil
 	}
 }

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -32,7 +32,7 @@ func loadEnv() error {
 	}
 	viper.SetDefault("habitat_path", filepath.Join(homedir, ".habitat"))
 
-	err = viper.BindEnv("habitat_app_path")
+	err = viper.BindEnv("habitat_app_path", "HABITAT_APP_PATH")
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,11 @@ func (n *NodeConfig) HabitatPath() string {
 
 func (n *NodeConfig) HabitatAppPath() string {
 	// Note that in dev mode, this should point to a path on the host machine rather than in the Docker container.
-	return viper.GetString("habitat_app_path")
+	path := viper.GetString("habitat_app_path")
+	if path == "" {
+		return filepath.Join(n.HabitatPath(), "apps")
+	}
+	return path
 }
 
 func (n *NodeConfig) HDBPath() string {

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -53,6 +53,12 @@ func loadEnv() error {
 		return err
 	}
 
+	err = viper.BindEnv("frontend_dev", "FRONTEND_DEV")
+	if err != nil {
+		return err
+	}
+	viper.SetDefault("frontend_dev", false)
+
 	return nil
 }
 
@@ -203,6 +209,10 @@ func (n *NodeConfig) TailscaleAuthkey() string {
 func (n *NodeConfig) TailScaleStatePath() string {
 	// Note: this is intentionally not configurable for simplicity's sake.
 	return filepath.Join(n.HabitatPath(), "tailscale_state")
+}
+
+func (n *NodeConfig) FrontendDev() bool {
+	return viper.GetBool("frontend_dev")
 }
 
 func homedir() (string, error) {

--- a/internal/node/docker/driver.go
+++ b/internal/node/docker/driver.go
@@ -73,7 +73,7 @@ func (d *AppDriver) IsInstalled(packageSpec *node.Package, version string) (bool
 	if err != nil {
 		return false, err
 	}
-	return !(len(images) > 0), nil
+	return len(images) > 0, nil
 }
 
 // Implement the package manager interface

--- a/internal/node/hdb/hdbms/db.go
+++ b/internal/node/hdb/hdbms/db.go
@@ -12,20 +12,20 @@ type HDBResult struct {
 	StateUpdatePublisher pubsub.Publisher[hdb.StateUpdate] `group:"state_update_publishers"`
 }
 
-func NewHabitatDB(logger *zerolog.Logger, publisher *pubsub.SimplePublisher[hdb.StateUpdate], config *config.NodeConfig) (HDBResult, func(), error) {
+func NewHabitatDB(logger *zerolog.Logger, publisher *pubsub.SimplePublisher[hdb.StateUpdate], config *config.NodeConfig) (*HDBResult, func(), error) {
 	dbManager, err := NewDatabaseManager(config, publisher)
 	if err != nil {
-		return HDBResult{}, func() {}, err
+		return nil, nil, err
 	}
 
 	err = dbManager.RestartDBs()
 	if err != nil {
-		return HDBResult{}, func() {}, err
+		return nil, nil, err
 	}
 
 	go dbManager.Start()
 
-	return HDBResult{
+	return &HDBResult{
 		Manager:              dbManager,
 		StateUpdatePublisher: publisher,
 	}, dbManager.Stop, nil


### PR DESCRIPTION
This PR fixes some bugs with installation and makes the frontend embeddable inside the habitat node binary. The frontend is served with minimal additional setup when deployed.
