### PR TITLE
Eagraf/start pds after install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         node-version: 22
 
+    - name: Set up pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
     - name: Get dependencies
       run: |
         go get -v -t -d ./...

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,6 @@ $(TOPDIR)/bin/amd64-darwin/habitat-amd64-darwin.tar.gz: $(TOPDIR)/bin/amd64-darw
 
 # Embed the frontend in the binary
 internal/frontend/build:
-	cd $(TOPDIR)/frontend && npm install && npm run build
+	cd $(TOPDIR)/frontend && pnpm install && pnpm run build
 	mkdir -p $(TOPDIR)/internal/frontend/build
 	cp -r $(TOPDIR)/frontend/out/* $(TOPDIR)/internal/frontend/build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To run all the code and tooling in this repository, you will need to have the fo
 * golangci-lint: https://golangci-lint.run/usage/install/
 * go-test-coverage: Run `go install github.com/vladopajic/go-test-coverage/v2@latest`
 * Postman: https://www.postman.com/downloads/
+* pnpm: https://pnpm.io/installation
+* NodeJS: https://nodejs.org/en/download/package-manager
 
 ## Local Development
 The local dev setup runs the main Habitat node in a docker container. The code is built inside the container using [Air](https://github.com/cosmtrek/air), which allows for live reloading. To build the dev container, run:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ make test-coverage
 ```
 This repository uses [gomock](https://github.com/uber-go/mock) to create mocks in tests. Generally, mocks will be generated with a command looking like this that writes the mock code into a `mocks` package sitting next to where the real code lives:
 ```
+// If you haven't installed before, run $go install go.uber.org/mock/mockgen@latest
 mockgen -source=internal/node/hdb/dbms.go -package mocks > internal/node/hdb/mocks/mock_dbms.go
 ```
 The mocks can be regenerated as needed when the interface they are mocking is changed. 

--- a/build/compose.yml
+++ b/build/compose.yml
@@ -33,4 +33,5 @@ services:
     env_file: ../dev.env
     depends_on:
       - habitat_frontend
-
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/build/compose.yml
+++ b/build/compose.yml
@@ -1,4 +1,4 @@
-name: habitat-node
+version: "3.3"
 services:
   habitat_frontend:
     image: habitat_frontend
@@ -30,9 +30,7 @@ services:
     build: 
       context: ..
       dockerfile: build/node.dev.Dockerfile
-    env_file:
-      - path: ../dev.env
-        required: false
+    env_file: ../dev.env
     depends_on:
       - habitat_frontend
 

--- a/core/state/node/migrations_test.go
+++ b/core/state/node/migrations_test.go
@@ -76,7 +76,7 @@ func TestValidationFailure(t *testing.T) {
 	state, err := nodeSchema.EmptyState()
 	assert.Nil(t, err)
 
-	state.(*NodeState).TestField = "test"
+	state.(*State).TestField = "test"
 	err = state.Validate()
 	assert.NotNil(t, err)
 }
@@ -91,7 +91,7 @@ func TestBackwardsCompatibility(t *testing.T) {
 	// changing this test to make your code pass.
 
 	// NodeSchema in v0.0.1
-	nodeState := &NodeState{
+	nodeState := &State{
 		NodeID:        "node1",
 		Name:          "My Node",
 		Certificate:   "Fake certificate",

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -63,12 +63,20 @@ func (s NodeState) Bytes() ([]byte, error) {
 }
 
 func (s NodeState) GetAppByID(appID string) (*AppInstallationState, error) {
+	app, ok := s.AppInstallations[appID]
+	if !ok {
+		return nil, fmt.Errorf("app with ID %s not found", appID)
+	}
+	return app, nil
+}
+
+func (s NodeState) GetAppByName(appName string) (*AppInstallationState, error) {
 	for _, app := range s.AppInstallations {
-		if app.ID == appID {
+		if app.Name == appName {
 			return app, nil
 		}
 	}
-	return nil, fmt.Errorf("app with ID %s not found", appID)
+	return nil, fmt.Errorf("app with name %s not found", appName)
 }
 
 func (s NodeState) GetAppsForUser(userID string) ([]*AppInstallationState, error) {

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -70,15 +70,6 @@ func (s NodeState) GetAppByID(appID string) (*AppInstallationState, error) {
 	return app, nil
 }
 
-func (s NodeState) GetAppByName(appName string) (*AppInstallationState, error) {
-	for _, app := range s.AppInstallations {
-		if app.Name == appName {
-			return app, nil
-		}
-	}
-	return nil, fmt.Errorf("app with name %s not found", appName)
-}
-
 func (s NodeState) GetAppsForUser(userID string) ([]*AppInstallationState, error) {
 	apps := make([]*AppInstallationState, 0)
 	for _, app := range s.AppInstallations {

--- a/core/state/node/schema.go
+++ b/core/state/node/schema.go
@@ -20,7 +20,7 @@ var nodeSchemaRaw string
 
 // TODO structs defined here can embed the immutable structs, but also include mutable fields.
 
-type NodeState struct {
+type State struct {
 	NodeID            string                           `json:"node_id"`
 	Name              string                           `json:"name"`
 	Certificate       string                           `json:"certificate"` // TODO turn this into b64
@@ -53,16 +53,16 @@ type ProcessState struct {
 	ExtDriverID string `json:"ext_driver_id"`
 }
 
-func (s NodeState) Schema() hdb.Schema {
+func (s State) Schema() hdb.Schema {
 	ns := &NodeSchema{}
 	return ns
 }
 
-func (s NodeState) Bytes() ([]byte, error) {
+func (s State) Bytes() ([]byte, error) {
 	return json.Marshal(s)
 }
 
-func (s NodeState) GetAppByID(appID string) (*AppInstallationState, error) {
+func (s State) GetAppByID(appID string) (*AppInstallationState, error) {
 	app, ok := s.AppInstallations[appID]
 	if !ok {
 		return nil, fmt.Errorf("app with ID %s not found", appID)
@@ -70,7 +70,7 @@ func (s NodeState) GetAppByID(appID string) (*AppInstallationState, error) {
 	return app, nil
 }
 
-func (s NodeState) GetAppsForUser(userID string) ([]*AppInstallationState, error) {
+func (s State) GetAppsForUser(userID string) ([]*AppInstallationState, error) {
 	apps := make([]*AppInstallationState, 0)
 	for _, app := range s.AppInstallations {
 		if app.UserID == userID {
@@ -80,7 +80,7 @@ func (s NodeState) GetAppsForUser(userID string) ([]*AppInstallationState, error
 	return apps, nil
 }
 
-func (s NodeState) GetProcessesForUser(userID string) ([]*ProcessState, error) {
+func (s State) GetProcessesForUser(userID string) ([]*ProcessState, error) {
 	procs := make([]*ProcessState, 0)
 	for _, proc := range s.Processes {
 		if proc.UserID == userID {
@@ -90,7 +90,7 @@ func (s NodeState) GetProcessesForUser(userID string) ([]*ProcessState, error) {
 	return procs, nil
 }
 
-func (s NodeState) GetReverseProxyRulesForProcess(processID string) ([]*ReverseProxyRule, error) {
+func (s State) GetReverseProxyRulesForProcess(processID string) ([]*ReverseProxyRule, error) {
 	process, ok := s.Processes[processID]
 	if !ok {
 		return nil, fmt.Errorf("process with ID %s not found", processID)
@@ -108,12 +108,12 @@ func (s NodeState) GetReverseProxyRulesForProcess(processID string) ([]*ReverseP
 	return rules, nil
 }
 
-func (s NodeState) Copy() (*NodeState, error) {
+func (s State) Copy() (*State, error) {
 	marshaled, err := s.Bytes()
 	if err != nil {
 		return nil, err
 	}
-	var copy NodeState
+	var copy State
 	err = json.Unmarshal(marshaled, &copy)
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (s NodeState) Copy() (*NodeState, error) {
 	return &copy, nil
 }
 
-func (s NodeState) Validate() error {
+func (s State) Validate() error {
 	schemaVersion := s.SchemaVersion
 
 	ns := &NodeSchema{}
@@ -158,11 +158,11 @@ func (s *NodeSchema) EmptyState() (hdb.State, error) {
 }
 
 func (s *NodeSchema) Type() reflect.Type {
-	return reflect.TypeOf(&NodeState{})
+	return reflect.TypeOf(&State{})
 }
 
 func (s *NodeSchema) InitializationTransition(initState []byte) (hdb.Transition, error) {
-	var is *NodeState
+	var is *State
 	err := json.Unmarshal(initState, &is)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (s *NodeSchema) JSONSchemaForVersion(version string) (*jsonschema.Schema, e
 }
 
 func (s *NodeSchema) ValidateState(state []byte) error {
-	var stateObj NodeState
+	var stateObj State
 	err := json.Unmarshal(state, &stateObj)
 	if err != nil {
 		return err

--- a/core/state/node/schema_test.go
+++ b/core/state/node/schema_test.go
@@ -54,7 +54,7 @@ func TestInitializationTransition(t *testing.T) {
 }
 
 func TestGetAppByID(t *testing.T) {
-	state := &NodeState{
+	state := &State{
 		AppInstallations: map[string]*AppInstallationState{
 			"app1": {
 				AppInstallation: &AppInstallation{
@@ -74,7 +74,7 @@ func TestGetAppByID(t *testing.T) {
 
 func TestGetReverseProxyRulesForProcess(t *testing.T) {
 
-	state := &NodeState{
+	state := &State{
 		AppInstallations: map[string]*AppInstallationState{
 			"app1": {
 				AppInstallation: &AppInstallation{

--- a/core/state/node/test_helpers/helpers.go
+++ b/core/state/node/test_helpers/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 )
 
-func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) (hdb.StateUpdate, error) {
+func StateUpdateTestHelper(transition hdb.Transition, newState *node.State) (hdb.StateUpdate, error) {
 	stateBytes, err := newState.Bytes()
 	if err != nil {
 		return nil, err

--- a/core/state/node/test_helpers/helpers.go
+++ b/core/state/node/test_helpers/helpers.go
@@ -13,15 +13,13 @@ func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) 
 		return nil, err
 	}
 
-	stateBytes, err := json.Marshal(newState)
-	if err != nil {
-		return nil, err
-	}
+	updateInternal := node.NewNodeStateUpdateInternal(newState, &hdb.TransitionWrapper{
+		Transition: transBytes,
+		Type:       transition.Type(),
+	})
 
 	return &hdb.StateUpdate{
-		SchemaType:     node.SchemaName,
-		Transition:     transBytes,
-		TransitionType: transition.Type(),
-		NewState:       stateBytes,
+		SchemaType:          node.SchemaName,
+		StateUpdateInternal: updateInternal,
 	}, nil
 }

--- a/core/state/node/test_helpers/helpers.go
+++ b/core/state/node/test_helpers/helpers.go
@@ -8,6 +8,11 @@ import (
 )
 
 func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) (*hdb.StateUpdate, error) {
+	stateBytes, err := newState.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	err = transition.Enrich(stateBytes)
 	transBytes, err := json.Marshal(transition)
 	if err != nil {
 		return nil, err

--- a/core/state/node/test_helpers/helpers.go
+++ b/core/state/node/test_helpers/helpers.go
@@ -13,6 +13,11 @@ func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) 
 		return nil, err
 	}
 	err = transition.Enrich(stateBytes)
+	if err != nil {
+		return nil, err
+
+	}
+
 	transBytes, err := json.Marshal(transition)
 	if err != nil {
 		return nil, err

--- a/core/state/node/test_helpers/helpers.go
+++ b/core/state/node/test_helpers/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 )
 
-func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) (*hdb.StateUpdate, error) {
+func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) (hdb.StateUpdate, error) {
 	stateBytes, err := newState.Bytes()
 	if err != nil {
 		return nil, err
@@ -18,13 +18,9 @@ func StateUpdateTestHelper(transition hdb.Transition, newState *node.NodeState) 
 		return nil, err
 	}
 
-	updateInternal := node.NewNodeStateUpdateInternal(newState, &hdb.TransitionWrapper{
+	return node.NewNodeStateUpdate(newState, &hdb.TransitionWrapper{
 		Transition: transBytes,
 		Type:       transition.Type(),
-	})
+	}, hdb.NewStateUpdateMetadata(1000, node.SchemaName, "test_db")), nil
 
-	return &hdb.StateUpdate{
-		SchemaType:          node.SchemaName,
-		StateUpdateInternal: updateInternal,
-	}, nil
 }

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -374,8 +373,7 @@ func (t *FinishInstallationTransition) Validate(oldState []byte) error {
 
 type ProcessStartTransition struct {
 	// Requested data
-	AppID   string
-	AppName string
+	AppID string
 
 	EnrichedData *ProcessStartTransitionEnrichedData
 }
@@ -415,27 +413,9 @@ func (t *ProcessStartTransition) Enrich(oldState []byte) error {
 		return err
 	}
 
-	if t.AppID == "" && t.AppName == "" {
-		return errors.New("no app identifier supplied")
-	}
-
-	if t.AppID != "" && t.AppName != "" {
-		return errors.New("both AppID and AppName supplied, please choose one")
-	}
-
-	var app *AppInstallationState
-	if t.AppName != "" {
-		a, err := oldNode.GetAppByName(t.AppName)
-		if err != nil {
-			return err
-		}
-		app = a
-	} else {
-		a, err := oldNode.GetAppByID(t.AppID)
-		if err != nil {
-			return err
-		}
-		app = a
+	app, err := oldNode.GetAppByID(t.AppID)
+	if err != nil {
+		return err
 	}
 
 	proc := &ProcessState{

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -22,7 +22,7 @@ var (
 )
 
 type InitalizationTransition struct {
-	InitState *NodeState `json:"init_state"`
+	InitState *State `json:"init_state"`
 }
 
 func (t *InitalizationTransition) Type() string {
@@ -73,7 +73,7 @@ func (t *MigrationTransition) Type() string {
 }
 
 func (t *MigrationTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (t *MigrationTransition) Enrich(oldState []byte) error {
 }
 
 func (t *MigrationTransition) Validate(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -161,7 +161,7 @@ func (t *AddUserTransition) Enrich(oldState []byte) error {
 
 func (t *AddUserTransition) Validate(oldState []byte) error {
 
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -200,7 +200,7 @@ func (t *StartInstallationTransition) Type() string {
 }
 
 func (t *StartInstallationTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func (t *StartInstallationTransition) Enrich(oldState []byte) error {
 }
 
 func (t *StartInstallationTransition) Validate(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -324,7 +324,7 @@ func (t *FinishInstallationTransition) Type() string {
 }
 
 func (t *FinishInstallationTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (t *FinishInstallationTransition) Enrich(oldState []byte) error {
 }
 
 func (t *FinishInstallationTransition) Validate(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -388,7 +388,7 @@ func (t *ProcessStartTransition) Type() string {
 }
 
 func (t *ProcessStartTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -407,7 +407,7 @@ func (t *ProcessStartTransition) Patch(oldState []byte) ([]byte, error) {
 }
 
 func (t *ProcessStartTransition) Enrich(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -440,7 +440,7 @@ func (t *ProcessStartTransition) Enrich(oldState []byte) error {
 
 func (t *ProcessStartTransition) Validate(oldState []byte) error {
 
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -488,7 +488,7 @@ func (t *ProcessRunningTransition) Type() string {
 }
 
 func (t *ProcessRunningTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -518,7 +518,7 @@ func (t *ProcessRunningTransition) Enrich(oldState []byte) error {
 }
 
 func (t *ProcessRunningTransition) Validate(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err
@@ -545,7 +545,7 @@ func (t *ProcessStopTransition) Type() string {
 }
 
 func (t *ProcessStopTransition) Patch(oldState []byte) ([]byte, error) {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return nil, err
@@ -567,7 +567,7 @@ func (t *ProcessStopTransition) Enrich(oldState []byte) error {
 }
 
 func (t *ProcessStopTransition) Validate(oldState []byte) error {
-	var oldNode NodeState
+	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
 		return err

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/google/uuid"
 )
 
@@ -29,7 +30,7 @@ func (t *InitalizationTransition) Type() string {
 	return TransitionInitialize
 }
 
-func (t *InitalizationTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *InitalizationTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	if t.InitState.Users == nil {
 		t.InitState.Users = make(map[string]*User, 0)
 	}
@@ -53,11 +54,11 @@ func (t *InitalizationTransition) Patch(oldState []byte) ([]byte, error) {
 	}]`, marshaled)), nil
 }
 
-func (t *InitalizationTransition) Enrich(oldState []byte) error {
+func (t *InitalizationTransition) Enrich(oldState hdb.SerializedState) error {
 	return nil
 }
 
-func (t *InitalizationTransition) Validate(oldState []byte) error {
+func (t *InitalizationTransition) Validate(oldState hdb.SerializedState) error {
 	if t.InitState == nil {
 		return fmt.Errorf("init state cannot be nil")
 	}
@@ -72,7 +73,7 @@ func (t *MigrationTransition) Type() string {
 	return TransitionMigrationUp
 }
 
-func (t *MigrationTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *MigrationTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -87,11 +88,11 @@ func (t *MigrationTransition) Patch(oldState []byte) ([]byte, error) {
 	return json.Marshal(patch)
 }
 
-func (t *MigrationTransition) Enrich(oldState []byte) error {
+func (t *MigrationTransition) Enrich(oldState hdb.SerializedState) error {
 	return nil
 }
 
-func (t *MigrationTransition) Validate(oldState []byte) error {
+func (t *MigrationTransition) Validate(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -131,7 +132,7 @@ func (t *AddUserTransition) Type() string {
 	return TransitionAddUser
 }
 
-func (t *AddUserTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *AddUserTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 
 	user, err := json.Marshal(t.EnrichedData.User)
 	if err != nil {
@@ -145,7 +146,7 @@ func (t *AddUserTransition) Patch(oldState []byte) ([]byte, error) {
 	}]`, t.EnrichedData.User.ID, user)), nil
 }
 
-func (t *AddUserTransition) Enrich(oldState []byte) error {
+func (t *AddUserTransition) Enrich(oldState hdb.SerializedState) error {
 
 	id := uuid.New().String()
 
@@ -159,7 +160,7 @@ func (t *AddUserTransition) Enrich(oldState []byte) error {
 	return nil
 }
 
-func (t *AddUserTransition) Validate(oldState []byte) error {
+func (t *AddUserTransition) Validate(oldState hdb.SerializedState) error {
 
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
@@ -199,7 +200,7 @@ func (t *StartInstallationTransition) Type() string {
 	return TransitionStartInstallation
 }
 
-func (t *StartInstallationTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *StartInstallationTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -244,7 +245,7 @@ func (t *StartInstallationTransition) Patch(oldState []byte) ([]byte, error) {
 	]`, t.EnrichedData.AppState.ID, string(marshalledApp), rules)), nil
 }
 
-func (t *StartInstallationTransition) Enrich(oldState []byte) error {
+func (t *StartInstallationTransition) Enrich(oldState hdb.SerializedState) error {
 	id := uuid.New().String()
 	appInstallState := &AppInstallationState{
 		AppInstallation: &AppInstallation{
@@ -278,7 +279,7 @@ func (t *StartInstallationTransition) Enrich(oldState []byte) error {
 	return nil
 }
 
-func (t *StartInstallationTransition) Validate(oldState []byte) error {
+func (t *StartInstallationTransition) Validate(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -323,7 +324,7 @@ func (t *FinishInstallationTransition) Type() string {
 	return TransitionFinishInstallation
 }
 
-func (t *FinishInstallationTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *FinishInstallationTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -337,11 +338,11 @@ func (t *FinishInstallationTransition) Patch(oldState []byte) ([]byte, error) {
 	}]`, t.AppID, AppLifecycleStateInstalled)), nil
 }
 
-func (t *FinishInstallationTransition) Enrich(oldState []byte) error {
+func (t *FinishInstallationTransition) Enrich(oldState hdb.SerializedState) error {
 	return nil
 }
 
-func (t *FinishInstallationTransition) Validate(oldState []byte) error {
+func (t *FinishInstallationTransition) Validate(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -387,7 +388,7 @@ func (t *ProcessStartTransition) Type() string {
 	return TransitionStartProcess
 }
 
-func (t *ProcessStartTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *ProcessStartTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -406,7 +407,7 @@ func (t *ProcessStartTransition) Patch(oldState []byte) ([]byte, error) {
 		}]`, t.EnrichedData.Process.ID, marshaled)), nil
 }
 
-func (t *ProcessStartTransition) Enrich(oldState []byte) error {
+func (t *ProcessStartTransition) Enrich(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -438,7 +439,7 @@ func (t *ProcessStartTransition) Enrich(oldState []byte) error {
 	return nil
 }
 
-func (t *ProcessStartTransition) Validate(oldState []byte) error {
+func (t *ProcessStartTransition) Validate(oldState hdb.SerializedState) error {
 
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
@@ -487,7 +488,7 @@ func (t *ProcessRunningTransition) Type() string {
 	return TransitionProcessRunning
 }
 
-func (t *ProcessRunningTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *ProcessRunningTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -513,11 +514,11 @@ func (t *ProcessRunningTransition) Patch(oldState []byte) ([]byte, error) {
 	}]`, t.ProcessID, marshaled)), nil
 }
 
-func (t *ProcessRunningTransition) Enrich(oldState []byte) error {
+func (t *ProcessRunningTransition) Enrich(oldState hdb.SerializedState) error {
 	return nil
 }
 
-func (t *ProcessRunningTransition) Validate(oldState []byte) error {
+func (t *ProcessRunningTransition) Validate(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -544,7 +545,7 @@ func (t *ProcessStopTransition) Type() string {
 	return TransitionStopProcess
 }
 
-func (t *ProcessStopTransition) Patch(oldState []byte) ([]byte, error) {
+func (t *ProcessStopTransition) Patch(oldState hdb.SerializedState) (hdb.SerializedState, error) {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {
@@ -562,11 +563,11 @@ func (t *ProcessStopTransition) Patch(oldState []byte) ([]byte, error) {
 	}]`, t.ProcessID)), nil
 }
 
-func (t *ProcessStopTransition) Enrich(oldState []byte) error {
+func (t *ProcessStopTransition) Enrich(oldState hdb.SerializedState) error {
 	return nil
 }
 
-func (t *ProcessStopTransition) Validate(oldState []byte) error {
+func (t *ProcessStopTransition) Validate(oldState hdb.SerializedState) error {
 	var oldNode State
 	err := json.Unmarshal(oldState, &oldNode)
 	if err != nil {

--- a/core/state/node/transitions.go
+++ b/core/state/node/transitions.go
@@ -183,7 +183,9 @@ func (t *AddUserTransition) Validate(oldState []byte) error {
 }
 
 type StartInstallationTransition struct {
-	UserID string `json:"user_id"`
+	UserID                 string `json:"user_id"`
+	StartAfterInstallation bool   `json:"start_after_installation"`
+
 	*AppInstallation
 	NewProxyRules []*ReverseProxyRule                      `json:"new_proxy_rules"`
 	EnrichedData  *StartInstallationTransitionEnrichedData `json:"enriched_data"`
@@ -314,6 +316,8 @@ type FinishInstallationTransition struct {
 	AppID           string `json:"app_id"`
 	RegistryURLBase string `json:"registry_url_base"`
 	RegistryAppID   string `json:"registry_app_id"`
+
+	StartAfterInstallation bool `json:"start_after_installation"`
 }
 
 func (t *FinishInstallationTransition) Type() string {

--- a/core/state/node/transitions_test.go
+++ b/core/state/node/transitions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testTransitions(oldState *NodeState, transitions []hdb.Transition) (*NodeState, error) {
@@ -35,7 +36,12 @@ func testTransitions(oldState *NodeState, transitions []hdb.Transition) (*NodeSt
 			return nil, fmt.Errorf("transition type is empty")
 		}
 
-		err := t.Validate(oldJSONState.Bytes())
+		err := t.Enrich(oldJSONState.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("transition enrichment failed: %s", err)
+		}
+
+		err = t.Validate(oldJSONState.Bytes())
 		if err != nil {
 			return nil, fmt.Errorf("transition validation failed: %s", err)
 		}
@@ -125,7 +131,6 @@ func TestAddingUsers(t *testing.T) {
 			},
 		},
 		&AddUserTransition{
-			UserID:      "123",
 			Username:    "eagraf",
 			Certificate: "placeholder",
 		},
@@ -141,24 +146,12 @@ func TestAddingUsers(t *testing.T) {
 
 	testSecondUserConflictOnUsername := []hdb.Transition{
 		&AddUserTransition{
-			UserID:      "456",
 			Username:    "eagraf",
 			Certificate: "placeholder",
 		},
 	}
 
 	_, err = testTransitionsOnCopy(newState, testSecondUserConflictOnUsername)
-	assert.NotNil(t, err)
-
-	testSecondUserConflictOnUserID := []hdb.Transition{
-		&AddUserTransition{
-			UserID:      "123",
-			Username:    "eagraf2",
-			Certificate: "placeholder",
-		},
-	}
-
-	_, err = testTransitionsOnCopy(newState, testSecondUserConflictOnUserID)
 	assert.NotNil(t, err)
 }
 
@@ -170,18 +163,18 @@ func TestAppLifecycle(t *testing.T) {
 				Certificate:   "123",
 				Name:          "New Node",
 				SchemaVersion: LatestVersion,
-				Users:         make(map[string]*User, 0),
+				Users: map[string]*User{
+					"123": {
+						ID:          "123",
+						Username:    "eagraf",
+						Certificate: "placeholder",
+					},
+				},
 			},
-		},
-		&AddUserTransition{
-			UserID:      "123",
-			Username:    "eagraf",
-			Certificate: "placeholder",
 		},
 		&StartInstallationTransition{
 			UserID: "123",
 			AppInstallation: &AppInstallation{
-				UserID:  "123",
 				Name:    "app_name1",
 				Version: "1",
 				Package: Package{
@@ -197,8 +190,8 @@ func TestAppLifecycle(t *testing.T) {
 	}
 
 	newState, err := testTransitions(nil, transitions)
-	assert.Nil(t, err)
-	assert.NotNil(t, newState)
+	require.Nil(t, err)
+	require.NotNil(t, newState)
 	assert.Equal(t, "abc", newState.NodeID)
 	assert.Equal(t, "123", newState.Certificate)
 	assert.Equal(t, "New Node", newState.Name)
@@ -312,18 +305,18 @@ func TestAppInstallReverseProxyRules(t *testing.T) {
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
 			InitState: &NodeState{
-				NodeID:            "abc",
-				Certificate:       "123",
-				Name:              "New Node",
-				SchemaVersion:     LatestVersion,
-				Users:             make(map[string]*User, 0),
+				NodeID:        "abc",
+				Certificate:   "123",
+				Name:          "New Node",
+				SchemaVersion: LatestVersion,
+				Users: map[string]*User{
+					"123": &User{
+						Username:    "eagraf",
+						Certificate: "placeholder",
+					},
+				},
 				ReverseProxyRules: &proxyRules,
 			},
-		},
-		&AddUserTransition{
-			UserID:      "123",
-			Username:    "eagraf",
-			Certificate: "placeholder",
 		},
 		&StartInstallationTransition{
 			UserID: "123",
@@ -351,8 +344,8 @@ func TestAppInstallReverseProxyRules(t *testing.T) {
 	}
 
 	newState, err := testTransitions(nil, transitions)
-	assert.Nil(t, err)
-	assert.NotNil(t, newState)
+	require.Nil(t, err)
+	require.NotNil(t, newState)
 }
 
 func TestProcesses(t *testing.T) {
@@ -376,6 +369,7 @@ func TestProcesses(t *testing.T) {
 						AppInstallation: &AppInstallation{
 							ID:      "App1",
 							Name:    "app_name1",
+							UserID:  "123",
 							Version: "1",
 							Package: Package{
 								Driver:             "docker",
@@ -391,28 +385,13 @@ func TestProcesses(t *testing.T) {
 			},
 		},
 		&ProcessStartTransition{
-			Process: &Process{
-				AppID:  "App1",
-				UserID: "123",
-				Driver: "docker",
-			},
-			App: &AppInstallation{
-				ID:      "App1",
-				Name:    "app_name1",
-				Version: "1",
-				Package: Package{
-					Driver:             "docker",
-					RegistryURLBase:    "https://registry.com",
-					RegistryPackageID:  "app_name1",
-					RegistryPackageTag: "v1",
-				},
-			},
+			AppID: "App1",
 		},
 	}
 
 	newState, err := testTransitions(nil, transitions)
-	assert.Nil(t, err)
-	assert.NotNil(t, newState)
+	require.Nil(t, err)
+	require.NotNil(t, newState)
 	assert.Equal(t, "abc", newState.NodeID)
 	assert.Equal(t, "123", newState.Certificate)
 	assert.Equal(t, "New Node", newState.Name)
@@ -452,30 +431,6 @@ func TestProcesses(t *testing.T) {
 	_, err = testTransitionsOnCopy(newState, testProcessRunningNoMatchingID)
 	assert.NotNil(t, err)
 
-	testProcessIDConflict := []hdb.Transition{
-		&ProcessStartTransition{
-			Process: &Process{
-				ID:     "proc1",
-				AppID:  "App1",
-				UserID: "123",
-			},
-			App: &AppInstallation{
-				ID:      "App1",
-				Name:    "app_name1",
-				Version: "1",
-				Package: Package{
-					Driver:             "docker",
-					RegistryURLBase:    "https://registry.com",
-					RegistryPackageID:  "app_name1",
-					RegistryPackageTag: "v1",
-				},
-			},
-		},
-	}
-
-	_, err = testTransitionsOnCopy(newState, testProcessIDConflict)
-	assert.NotNil(t, err)
-
 	testProcessAlreadyRunning := []hdb.Transition{
 		&ProcessRunningTransition{
 			ProcessID: "proc1",
@@ -487,22 +442,7 @@ func TestProcesses(t *testing.T) {
 
 	testAppIDConflict := []hdb.Transition{
 		&ProcessStartTransition{
-			Process: &Process{
-				ID:     "proc2",
-				AppID:  "App1",
-				UserID: "123",
-			},
-			App: &AppInstallation{
-				ID:      "App1",
-				Name:    "app_name1",
-				Version: "1",
-				Package: Package{
-					Driver:             "docker",
-					RegistryURLBase:    "https://registry.com",
-					RegistryPackageID:  "app_name1",
-					RegistryPackageTag: "v1",
-				},
-			},
+			AppID: "App1",
 		},
 	}
 
@@ -521,20 +461,26 @@ func TestProcesses(t *testing.T) {
 
 	testUserDoesntExist := []hdb.Transition{
 		&ProcessStartTransition{
-			Process: &Process{
-				ID:     "proc2",
-				AppID:  "App1",
-				UserID: "456",
-			},
-			App: &AppInstallation{
-				ID:      "App1",
-				Name:    "app_name1",
-				Version: "1",
-				Package: Package{
-					Driver:             "docker",
-					RegistryURLBase:    "https://registry.com",
-					RegistryPackageID:  "app_name1",
-					RegistryPackageTag: "v1",
+			EnrichedData: &ProcessStartTransitionEnrichedData{
+				Process: &ProcessState{
+					Process: &Process{
+						ID:     "proc2",
+						AppID:  "App1",
+						UserID: "456",
+					},
+				},
+				App: &AppInstallationState{
+					AppInstallation: &AppInstallation{
+						ID:      "App1",
+						Name:    "app_name1",
+						Version: "1",
+						Package: Package{
+							Driver:             "docker",
+							RegistryURLBase:    "https://registry.com",
+							RegistryPackageID:  "app_name1",
+							RegistryPackageTag: "v1",
+						},
+					},
 				},
 			},
 		},
@@ -545,20 +491,26 @@ func TestProcesses(t *testing.T) {
 
 	testAppDoesntExist := []hdb.Transition{
 		&ProcessStartTransition{
-			Process: &Process{
-				ID:     "proc3",
-				AppID:  "App2",
-				UserID: "123",
-			},
-			App: &AppInstallation{
-				ID:      "App2",
-				Name:    "app_name1",
-				Version: "1",
-				Package: Package{
-					Driver:             "docker",
-					RegistryURLBase:    "https://registry.com",
-					RegistryPackageID:  "app_name1",
-					RegistryPackageTag: "v1",
+			EnrichedData: &ProcessStartTransitionEnrichedData{
+				Process: &ProcessState{
+					Process: &Process{
+						ID:     "proc3",
+						AppID:  "App2",
+						UserID: "123",
+					},
+				},
+				App: &AppInstallationState{
+					AppInstallation: &AppInstallation{
+						ID:      "App2",
+						Name:    "app_name1",
+						Version: "1",
+						Package: Package{
+							Driver:             "docker",
+							RegistryURLBase:    "https://registry.com",
+							RegistryPackageID:  "app_name1",
+							RegistryPackageTag: "v1",
+						},
+					},
 				},
 			},
 		},

--- a/core/state/node/transitions_test.go
+++ b/core/state/node/transitions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testTransitions(oldState *NodeState, transitions []hdb.Transition) (*NodeState, error) {
+func testTransitions(oldState *State, transitions []hdb.Transition) (*State, error) {
 	var oldJSONState *hdb.JSONState
 	schema := &NodeSchema{}
 	if oldState == nil {
@@ -64,7 +64,7 @@ func testTransitions(oldState *NodeState, transitions []hdb.Transition) (*NodeSt
 		oldJSONState = newState
 	}
 
-	var state NodeState
+	var state State
 	stateBytes := oldJSONState.Bytes()
 
 	err := json.Unmarshal(stateBytes, &state)
@@ -76,13 +76,13 @@ func testTransitions(oldState *NodeState, transitions []hdb.Transition) (*NodeSt
 }
 
 // use this if you expect the transitions to cause an error
-func testTransitionsOnCopy(oldState *NodeState, transitions []hdb.Transition) (*NodeState, error) {
+func testTransitionsOnCopy(oldState *State, transitions []hdb.Transition) (*State, error) {
 	marshaled, err := json.Marshal(oldState)
 	if err != nil {
 		return nil, err
 	}
 
-	var copy NodeState
+	var copy State
 	err = json.Unmarshal(marshaled, &copy)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func testTransitionsOnCopy(oldState *NodeState, transitions []hdb.Transition) (*
 func TestNodeInitialization(t *testing.T) {
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
@@ -123,7 +123,7 @@ func TestNodeInitialization(t *testing.T) {
 func TestAddingUsers(t *testing.T) {
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
@@ -158,7 +158,7 @@ func TestAddingUsers(t *testing.T) {
 func TestAppLifecycle(t *testing.T) {
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
@@ -304,7 +304,7 @@ func TestAppInstallReverseProxyRules(t *testing.T) {
 	proxyRules := make(map[string]*ReverseProxyRule)
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
@@ -352,7 +352,7 @@ func TestProcesses(t *testing.T) {
 
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",
@@ -532,7 +532,7 @@ func TestMigrationsTransition(t *testing.T) {
 
 	transitions := []hdb.Transition{
 		&InitalizationTransition{
-			InitState: &NodeState{
+			InitState: &State{
 				NodeID:        "abc",
 				Certificate:   "123",
 				Name:          "New Node",

--- a/core/state/node/update.go
+++ b/core/state/node/update.go
@@ -6,11 +6,11 @@ type NodeStateUpdate struct {
 	// Embed the metadata struct so this fully implements hdb.StateUpdate.
 	*hdb.StateUpdateMetadata
 
-	state             *NodeState
+	state             *State
 	transitionWrapper *hdb.TransitionWrapper
 }
 
-func NewNodeStateUpdate(state *NodeState, transitionWrapper *hdb.TransitionWrapper, metadata *hdb.StateUpdateMetadata) *NodeStateUpdate {
+func NewNodeStateUpdate(state *State, transitionWrapper *hdb.TransitionWrapper, metadata *hdb.StateUpdateMetadata) *NodeStateUpdate {
 	return &NodeStateUpdate{
 		state:               state,
 		transitionWrapper:   transitionWrapper,
@@ -30,6 +30,6 @@ func (n *NodeStateUpdate) TransitionType() string {
 	return n.transitionWrapper.Type
 }
 
-func (n *NodeStateUpdate) NodeState() *NodeState {
+func (n *NodeStateUpdate) NodeState() *State {
 	return n.state
 }

--- a/core/state/node/update.go
+++ b/core/state/node/update.go
@@ -3,14 +3,18 @@ package node
 import "github.com/eagraf/habitat-new/internal/node/hdb"
 
 type NodeStateUpdate struct {
+	// Embed the metadata struct so this fully implements hdb.StateUpdate.
+	*hdb.StateUpdateMetadata
+
 	state             *NodeState
 	transitionWrapper *hdb.TransitionWrapper
 }
 
-func NewNodeStateUpdateInternal(state *NodeState, transitionWrapper *hdb.TransitionWrapper) *NodeStateUpdate {
+func NewNodeStateUpdate(state *NodeState, transitionWrapper *hdb.TransitionWrapper, metadata *hdb.StateUpdateMetadata) *NodeStateUpdate {
 	return &NodeStateUpdate{
-		state:             state,
-		transitionWrapper: transitionWrapper,
+		state:               state,
+		transitionWrapper:   transitionWrapper,
+		StateUpdateMetadata: metadata,
 	}
 }
 

--- a/core/state/node/update.go
+++ b/core/state/node/update.go
@@ -1,0 +1,31 @@
+package node
+
+import "github.com/eagraf/habitat-new/internal/node/hdb"
+
+type NodeStateUpdate struct {
+	state             *NodeState
+	transitionWrapper *hdb.TransitionWrapper
+}
+
+func NewNodeStateUpdateInternal(state *NodeState, transitionWrapper *hdb.TransitionWrapper) *NodeStateUpdate {
+	return &NodeStateUpdate{
+		state:             state,
+		transitionWrapper: transitionWrapper,
+	}
+}
+
+func (n *NodeStateUpdate) NewState() hdb.State {
+	return n.state
+}
+
+func (n *NodeStateUpdate) Transition() []byte {
+	return n.transitionWrapper.Transition
+}
+
+func (n *NodeStateUpdate) TransitionType() string {
+	return n.transitionWrapper.Type
+}
+
+func (n *NodeStateUpdate) NodeState() *NodeState {
+	return n.state
+}

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -70,7 +70,7 @@ func (c *BaseNodeController) MigrateNodeDB(targetVersion string) error {
 		return err
 	}
 
-	var nodeState node.NodeState
+	var nodeState node.State
 	err = json.Unmarshal(dbClient.Bytes(), &nodeState)
 	if err != nil {
 		return nil
@@ -136,7 +136,7 @@ func (c *BaseNodeController) GetAppByID(appID string) (*node.AppInstallation, er
 		return nil, err
 	}
 
-	var nodeState node.NodeState
+	var nodeState node.State
 	err = json.Unmarshal(dbClient.Bytes(), &nodeState)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (c *BaseNodeController) StartProcess(appID string) error {
 		return err
 	}
 
-	var nodeState node.NodeState
+	var nodeState node.State
 	err = json.Unmarshal(dbClient.Bytes(), &nodeState)
 	if err != nil {
 		return nil
@@ -231,7 +231,7 @@ func (c *BaseNodeController) GetUserByUsername(username string) (*node.User, err
 		return nil, err
 	}
 
-	var nodeState node.NodeState
+	var nodeState node.State
 	err = json.Unmarshal(dbClient.Bytes(), &nodeState)
 	if err != nil {
 		return nil, err

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -23,7 +23,7 @@ type NodeController interface {
 	GetUserByUsername(username string) (*node.User, error)
 
 	InstallApp(userID string, newApp *node.AppInstallation, newProxyRules []*node.ReverseProxyRule) error
-	FinishAppInstallation(userID string, appID, registryURLBase, registryPackageID string) error
+	FinishAppInstallation(userID string, appID, registryURLBase, registryPackageID string, startAfterInstall bool) error
 	GetAppByID(appID string) (*node.AppInstallation, error)
 
 	StartProcess(appID string) error
@@ -107,7 +107,7 @@ func (c *BaseNodeController) InstallApp(userID string, newApp *node.AppInstallat
 }
 
 // FinishAppInstallation marks the app lifecycle state as installed
-func (c *BaseNodeController) FinishAppInstallation(userID string, appID, registryURLBase, registryAppID string) error {
+func (c *BaseNodeController) FinishAppInstallation(userID string, appID, registryURLBase, registryAppID string, startAfterInstall bool) error {
 	dbClient, err := c.databaseManager.GetDatabaseClientByName(constants.NodeDBDefaultName)
 	if err != nil {
 		return err
@@ -119,6 +119,8 @@ func (c *BaseNodeController) FinishAppInstallation(userID string, appID, registr
 			AppID:           appID,
 			RegistryURLBase: registryURLBase,
 			RegistryAppID:   registryAppID,
+
+			StartAfterInstallation: startAfterInstall,
 		},
 	})
 	if err != nil {

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -69,7 +69,7 @@ func TestMigrationController(t *testing.T) {
 
 	controller, mockedManager, mockClient := setupNodeDBTest(ctrl, t)
 
-	nodeState := &node.NodeState{
+	nodeState := &node.State{
 		SchemaVersion: "v0.0.2",
 	}
 	marshaled, err := nodeState.Bytes()
@@ -150,7 +150,7 @@ func TestInstallAppController(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-var nodeState = &node.NodeState{
+var nodeState = &node.State{
 	Users: map[string]*node.User{
 		"user_1": {
 			ID:       "user_1",

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -160,7 +160,8 @@ var nodeState = &node.NodeState{
 	AppInstallations: map[string]*node.AppInstallationState{
 		"app_1": {
 			AppInstallation: &node.AppInstallation{
-				ID: "app_1",
+				ID:     "app_1",
+				UserID: "0",
 			},
 			State: node.AppLifecycleStateInstalled,
 		},
@@ -228,14 +229,7 @@ func TestStartProcessController(t *testing.T) {
 	mockedClient.EXPECT().ProposeTransitions(gomock.Eq(
 		[]hdb.Transition{
 			&node.ProcessStartTransition{
-				Process: &node.Process{
-					ID:     "process_1",
-					AppID:  "app_1",
-					UserID: "user_1",
-				},
-				App: &node.AppInstallation{
-					ID: "app_1",
-				},
+				AppID: "app_1",
 			},
 		},
 	)).Return(nil, nil).Times(1)
@@ -255,11 +249,7 @@ func TestStartProcessController(t *testing.T) {
 		},
 	)).Return(nil, nil).Times(1)
 
-	err = controller.StartProcess(&node.Process{
-		ID:     "process_1",
-		AppID:  "app_1",
-		UserID: "user_1",
-	})
+	err = controller.StartProcess("app_1")
 	assert.Nil(t, err)
 
 	// Test setting the process to running, and then stopping it.
@@ -279,7 +269,6 @@ func TestAddUser(t *testing.T) {
 	mockedClient.EXPECT().ProposeTransitions(gomock.Eq(
 		[]hdb.Transition{
 			&node.AddUserTransition{
-				UserID:      "user_1",
 				Username:    "username_1",
 				Certificate: "cert_1",
 			},

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -185,7 +185,7 @@ func TestFinishAppInstallationController(t *testing.T) {
 		},
 	)).Return(nil, nil).Times(1)
 
-	err := controller.FinishAppInstallation("user_1", "app1", "https://registry.com", "app_1")
+	err := controller.FinishAppInstallation("user_1", "app1", "https://registry.com", "app_1", false)
 	assert.Nil(t, err)
 }
 

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -108,9 +108,10 @@ func initTranstitions(nodeConfig *config.NodeConfig) ([]hdb.Transition, error) {
 
 	for _, app := range defaultApplications {
 		transitions = append(transitions, &node.StartInstallationTransition{
-			UserID:          constants.RootUserID,
-			AppInstallation: app.AppInstallation,
-			NewProxyRules:   app.ReverseProxyRules,
+			UserID:                 constants.RootUserID,
+			AppInstallation:        app.AppInstallation,
+			NewProxyRules:          app.ReverseProxyRules,
+			StartAfterInstallation: true,
 		})
 	}
 	return transitions, nil

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -68,7 +68,7 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) types.PostAppRequest {
 
 // TODO this is basically a placeholder until we actually have a way of generating
 // the certificate for the node.
-func generateInitState(nodeConfig *config.NodeConfig) (*node.NodeState, error) {
+func generateInitState(nodeConfig *config.NodeConfig) (*node.State, error) {
 	nodeUUID := uuid.New().String()
 
 	rootCert := nodeConfig.RootUserCertB64()

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -41,12 +41,12 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) types.PostAppRequest {
 							Target: "/pds",
 						},
 					},
-					"exposed_ports": []string{"5000"},
+					"exposed_ports": []string{"5001"},
 					"port_bindings": map[nat.Port][]nat.PortBinding{
 						"3000/tcp": {
 							{
 								HostIP:   "0.0.0.0",
-								HostPort: "5000",
+								HostPort: "5001",
 							},
 						},
 					},
@@ -60,7 +60,7 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) types.PostAppRequest {
 			{
 				Type:    "redirect",
 				Matcher: "/xrpc",
-				Target:  "http://host.docker.internal:5000/xrpc",
+				Target:  "http://host.docker.internal:5001/xrpc",
 			},
 		},
 	}

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -45,7 +45,7 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) types.PostAppRequest {
 					"port_bindings": map[nat.Port][]nat.PortBinding{
 						"3000/tcp": {
 							{
-								HostIP:   "127.0.0.1",
+								HostIP:   "0.0.0.0",
 								HostPort: "5000",
 							},
 						},

--- a/internal/node/controller/mocks/mock_controller.go
+++ b/internal/node/controller/mocks/mock_controller.go
@@ -154,17 +154,17 @@ func (mr *MockNodeControllerMockRecorder) SetProcessRunning(processID any) *gomo
 }
 
 // StartProcess mocks base method.
-func (m *MockNodeController) StartProcess(process *node.Process) error {
+func (m *MockNodeController) StartProcess(appID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartProcess", process)
+	ret := m.ctrl.Call(m, "StartProcess", appID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartProcess indicates an expected call of StartProcess.
-func (mr *MockNodeControllerMockRecorder) StartProcess(process any) *gomock.Call {
+func (mr *MockNodeControllerMockRecorder) StartProcess(appID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartProcess", reflect.TypeOf((*MockNodeController)(nil).StartProcess), process)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartProcess", reflect.TypeOf((*MockNodeController)(nil).StartProcess), appID)
 }
 
 // StopProcess mocks base method.

--- a/internal/node/controller/mocks/mock_controller.go
+++ b/internal/node/controller/mocks/mock_controller.go
@@ -54,17 +54,17 @@ func (mr *MockNodeControllerMockRecorder) AddUser(userID, username, certificate 
 }
 
 // FinishAppInstallation mocks base method.
-func (m *MockNodeController) FinishAppInstallation(userID, appID, registryURLBase, registryPackageID string) error {
+func (m *MockNodeController) FinishAppInstallation(userID, appID, registryURLBase, registryPackageID string, startAfterInstall bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinishAppInstallation", userID, appID, registryURLBase, registryPackageID)
+	ret := m.ctrl.Call(m, "FinishAppInstallation", userID, appID, registryURLBase, registryPackageID, startAfterInstall)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FinishAppInstallation indicates an expected call of FinishAppInstallation.
-func (mr *MockNodeControllerMockRecorder) FinishAppInstallation(userID, appID, registryURLBase, registryPackageID any) *gomock.Call {
+func (mr *MockNodeControllerMockRecorder) FinishAppInstallation(userID, appID, registryURLBase, registryPackageID, startAfterInstall any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishAppInstallation", reflect.TypeOf((*MockNodeController)(nil).FinishAppInstallation), userID, appID, registryURLBase, registryPackageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishAppInstallation", reflect.TypeOf((*MockNodeController)(nil).FinishAppInstallation), userID, appID, registryURLBase, registryPackageID, startAfterInstall)
 }
 
 // GetAppByID mocks base method.

--- a/internal/node/controller/routes.go
+++ b/internal/node/controller/routes.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	types "github.com/eagraf/habitat-new/core/api"
-	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/constants"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"golang.org/x/mod/semver"
@@ -84,10 +83,7 @@ func (h *InstallAppRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO the user id should come from the authentication
-	// TODO request types that aren't coupled with the core domain types
 	appInstallation := req.AppInstallation
-	appInstallation.UserID = userID
 
 	err = h.nodeController.InstallApp(userID, appInstallation, req.ReverseProxyRules)
 	if err != nil {
@@ -125,21 +121,13 @@ func (h *StartProcessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	userID := r.Context().Value(constants.ContextKeyUserID).(string)
-
 	app, err := h.nodeController.GetAppByID(req.AppInstallationID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	process := &node.Process{
-		UserID: userID,
-		Driver: app.Driver,
-		AppID:  app.ID,
-	}
-
-	err = h.nodeController.StartProcess(process)
+	err = h.nodeController.StartProcess(app.ID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/node/controller/routes_test.go
+++ b/internal/node/controller/routes_test.go
@@ -74,6 +74,7 @@ func TestInstallAppHandler(t *testing.T) {
 
 	body := &types.PostAppRequest{
 		AppInstallation: &node.AppInstallation{
+			UserID:  "0",
 			Name:    "app_name1",
 			Version: "1",
 			Package: node.Package{
@@ -153,17 +154,8 @@ func TestStartProcessHandler(t *testing.T) {
 	}, nil).Times(1)
 
 	m.EXPECT().StartProcess(
-		gomock.Any(),
-	).DoAndReturn(func(process *node.Process) error {
-		assert.NotNil(t, process)
-		assert.Equal(t, "app_1", process.AppID)
-		assert.Equal(t, "user_1", process.UserID)
-		assert.Equal(t, "docker", process.Driver)
-		assert.Equal(t, "", process.Created)
-		assert.Equal(t, "", process.ID)
-
-		return nil
-	}).Times(1)
+		"app_1",
+	).Times(1)
 
 	// Test the happy path
 	resp := httptest.NewRecorder()

--- a/internal/node/hdb/hdbms/db.go
+++ b/internal/node/hdb/hdbms/db.go
@@ -45,7 +45,7 @@ func (s *StateUpdateLogger) ConsumeEvent(event *hdb.StateUpdate) error {
 		s.logger.Info().Msgf("Restoring state for %s", event.DatabaseID)
 		return nil
 	} else {
-		s.logger.Info().Msgf("Applying transition %s to %s", string(event.Transition), event.DatabaseID)
+		s.logger.Info().Msgf("Applying transition %s to %s", string(event.TransitionType()), event.DatabaseID)
 		return nil
 	}
 }

--- a/internal/node/hdb/hdbms/db.go
+++ b/internal/node/hdb/hdbms/db.go
@@ -40,12 +40,12 @@ func (s *StateUpdateLogger) Name() string {
 	return "StateUpdateLogger"
 }
 
-func (s *StateUpdateLogger) ConsumeEvent(event *hdb.StateUpdate) error {
-	if event.Restore {
-		s.logger.Info().Msgf("Restoring state for %s", event.DatabaseID)
+func (s *StateUpdateLogger) ConsumeEvent(event hdb.StateUpdate) error {
+	if event.IsRestore() {
+		s.logger.Info().Msgf("Restoring state for %s", event.DatabaseID())
 		return nil
 	} else {
-		s.logger.Info().Msgf("Applying transition %s to %s", string(event.TransitionType()), event.DatabaseID)
+		s.logger.Info().Msgf("Applying transition %s to %s", string(event.TransitionType()), event.DatabaseID())
 		return nil
 	}
 }

--- a/internal/node/hdb/hdbms/dbms.go
+++ b/internal/node/hdb/hdbms/dbms.go
@@ -9,7 +9,6 @@ import (
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/eagraf/habitat-new/internal/node/hdb/consensus"
 	"github.com/eagraf/habitat-new/internal/node/hdb/state"
-	"github.com/eagraf/habitat-new/internal/node/hdb/state/schemas"
 	"github.com/eagraf/habitat-new/internal/node/pubsub"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -106,7 +105,7 @@ func (dm *DatabaseManager) RestartDBs() error {
 		}
 		name := string(nameBytes)
 
-		schema, err := schemas.GetSchema(schemaType)
+		schema, err := state.GetSchema(schemaType)
 		if err != nil {
 			return err
 		}
@@ -127,7 +126,7 @@ func (dm *DatabaseManager) RestartDBs() error {
 			return fmt.Errorf("error restoring database %s: %s", dbID, err)
 		}
 
-		stateMachineController, err := schemas.StateMachineFactory(dbID, schemaType, nil, cluster, dm.publisher)
+		stateMachineController, err := state.StateMachineFactory(dbID, schemaType, nil, cluster, dm.publisher)
 		if err != nil {
 			return err
 		}
@@ -162,7 +161,7 @@ func (dm *DatabaseManager) CreateDatabase(name string, schemaType string, initia
 		return nil, err
 	}
 
-	schema, err := schemas.GetSchema(schemaType)
+	schema, err := state.GetSchema(schemaType)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +186,7 @@ func (dm *DatabaseManager) CreateDatabase(name string, schemaType string, initia
 		return nil, err
 	}
 
-	stateMachineController, err := schemas.StateMachineFactory(db.id, schemaType, nil, cluster, dm.publisher)
+	stateMachineController, err := state.StateMachineFactory(db.id, schemaType, nil, cluster, dm.publisher)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/hdb/state/factory.go
+++ b/internal/node/hdb/state/factory.go
@@ -56,7 +56,7 @@ func StateUpdateInternalFactory(
 ) (hdb.StateUpdate, error) {
 	switch schemaType {
 	case node.SchemaName:
-		var state node.NodeState
+		var state node.State
 		err := json.Unmarshal(stateBytes, &state)
 		if err != nil {
 			return nil, err

--- a/internal/node/hdb/state/factory.go
+++ b/internal/node/hdb/state/factory.go
@@ -1,11 +1,11 @@
-package schemas
+package state
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
-	"github.com/eagraf/habitat-new/internal/node/hdb/state"
 	"github.com/eagraf/habitat-new/internal/node/pubsub"
 )
 
@@ -19,7 +19,7 @@ func GetSchema(schemaType string) (hdb.Schema, error) {
 }
 
 // TODO this should account for schema version too
-func StateMachineFactory(databaseID string, schemaType string, emptyState []byte, replicator state.Replicator, publisher pubsub.Publisher[hdb.StateUpdate]) (state.StateMachineController, error) {
+func StateMachineFactory(databaseID string, schemaType string, emptyState []byte, replicator Replicator, publisher pubsub.Publisher[hdb.StateUpdate]) (StateMachineController, error) {
 	var schema hdb.Schema
 
 	switch schemaType {
@@ -41,9 +41,23 @@ func StateMachineFactory(databaseID string, schemaType string, emptyState []byte
 		emptyState = emptyStateBytes
 	}
 
-	stateMachineController, err := state.NewStateMachine(databaseID, schema, emptyState, replicator, publisher)
+	stateMachineController, err := NewStateMachine(databaseID, schema, emptyState, replicator, publisher)
 	if err != nil {
 		return nil, err
 	}
 	return stateMachineController, nil
+}
+
+func StateUpdateInternalFactory(schemaType string, stateBytes []byte, transitionWrapper *hdb.TransitionWrapper) (hdb.StateUpdateInternal, error) {
+	switch schemaType {
+	case node.SchemaName:
+		var state node.NodeState
+		err := json.Unmarshal(stateBytes, &state)
+		if err != nil {
+			return nil, err
+		}
+		return node.NewNodeStateUpdateInternal(&state, transitionWrapper), nil
+	default:
+		return nil, fmt.Errorf("schema type %s not found", schemaType)
+	}
 }

--- a/internal/node/hdb/state/factory.go
+++ b/internal/node/hdb/state/factory.go
@@ -48,7 +48,12 @@ func StateMachineFactory(databaseID string, schemaType string, emptyState []byte
 	return stateMachineController, nil
 }
 
-func StateUpdateInternalFactory(schemaType string, stateBytes []byte, transitionWrapper *hdb.TransitionWrapper) (hdb.StateUpdateInternal, error) {
+func StateUpdateInternalFactory(
+	schemaType string,
+	stateBytes []byte,
+	transitionWrapper *hdb.TransitionWrapper,
+	metadata *hdb.StateUpdateMetadata,
+) (hdb.StateUpdate, error) {
 	switch schemaType {
 	case node.SchemaName:
 		var state node.NodeState
@@ -56,7 +61,7 @@ func StateUpdateInternalFactory(schemaType string, stateBytes []byte, transition
 		if err != nil {
 			return nil, err
 		}
-		return node.NewNodeStateUpdateInternal(&state, transitionWrapper), nil
+		return node.NewNodeStateUpdate(&state, transitionWrapper, metadata), nil
 	default:
 		return nil, fmt.Errorf("schema type %s not found", schemaType)
 	}

--- a/internal/node/hdb/state/fsm.go
+++ b/internal/node/hdb/state/fsm.go
@@ -81,17 +81,14 @@ func (sm *RaftFSMAdapter) Apply(entry *raft.Log) interface{} {
 			log.Error().Msgf("error applying patch: %s", err)
 		}
 
-		updateInternal, err := StateUpdateInternalFactory(sm.schema.Name(), sm.jsonState.Bytes(), w)
+		metadata := hdb.NewStateUpdateMetadata(entry.Index, sm.schema.Name(), sm.databaseID)
+
+		update, err := StateUpdateInternalFactory(sm.schema.Name(), sm.jsonState.Bytes(), w, metadata)
 		if err != nil {
 			log.Error().Msgf("error creating state update internal: %s", err)
 		}
 
-		sm.updateChan <- hdb.StateUpdate{
-			Index:               entry.Index,
-			SchemaType:          sm.schema.Name(),
-			DatabaseID:          sm.databaseID,
-			StateUpdateInternal: updateInternal,
-		}
+		sm.updateChan <- update
 	}
 
 	return sm.JSONState()

--- a/internal/node/hdb/state/fsm.go
+++ b/internal/node/hdb/state/fsm.go
@@ -81,13 +81,16 @@ func (sm *RaftFSMAdapter) Apply(entry *raft.Log) interface{} {
 			log.Error().Msgf("error applying patch: %s", err)
 		}
 
+		updateInternal, err := StateUpdateInternalFactory(sm.schema.Name(), sm.jsonState.Bytes(), w)
+		if err != nil {
+			log.Error().Msgf("error creating state update internal: %s", err)
+		}
+
 		sm.updateChan <- hdb.StateUpdate{
-			Index:          entry.Index,
-			SchemaType:     sm.schema.Name(),
-			DatabaseID:     sm.databaseID,
-			TransitionType: w.Type,
-			Transition:     w.Transition,
-			NewState:       sm.jsonState.Bytes(),
+			Index:               entry.Index,
+			SchemaType:          sm.schema.Name(),
+			DatabaseID:          sm.databaseID,
+			StateUpdateInternal: updateInternal,
 		}
 	}
 

--- a/internal/node/hdb/state/state_machine.go
+++ b/internal/node/hdb/state/state_machine.go
@@ -75,14 +75,18 @@ func (sm *StateMachine) StartListening() {
 					}
 
 					// execute state update
-					jsonState, err := hdb.NewJSONState(sm.schema, stateUpdate.NewState)
+					stateBytes, err := stateUpdate.NewState().Bytes()
+					if err != nil {
+						log.Error().Err(err).Msgf("error getting new state bytes from state update chan")
+					}
+					jsonState, err := hdb.NewJSONState(sm.schema, stateBytes)
 					if err != nil {
 						log.Error().Err(err).Msgf("error getting new state from state update chan")
 					}
 					sm.jsonState = jsonState
 
 					if sm.restartIndex == stateUpdate.Index {
-						log.Info().Msgf("Restoring node state: %s", string(stateUpdate.NewState))
+						log.Info().Msgf("Restoring node state")
 						stateUpdate.Restore = true
 					}
 

--- a/internal/node/hdb/state/state_machine.go
+++ b/internal/node/hdb/state/state_machine.go
@@ -70,7 +70,7 @@ func (sm *StateMachine) StartListening() {
 					// Only apply state updates if the update index is greater than the restart index.
 					// If the update index is equal to the restart index, then the state update is a
 					// restore message which tells the subscribers to restore everything from the most up to date state.
-					if sm.restartIndex > stateUpdate.Index {
+					if sm.restartIndex > stateUpdate.Index() {
 						continue
 					}
 
@@ -85,12 +85,12 @@ func (sm *StateMachine) StartListening() {
 					}
 					sm.jsonState = jsonState
 
-					if sm.restartIndex == stateUpdate.Index {
+					if sm.restartIndex == stateUpdate.Index() {
 						log.Info().Msgf("Restoring node state")
-						stateUpdate.Restore = true
+						stateUpdate.SetRestore()
 					}
 
-					err = sm.publisher.PublishEvent(&stateUpdate)
+					err = sm.publisher.PublishEvent(stateUpdate)
 					if err != nil {
 						log.Error().Err(err).Msgf("error publishing state update")
 					}

--- a/internal/node/hdb/state/state_machine.go
+++ b/internal/node/hdb/state/state_machine.go
@@ -128,6 +128,11 @@ func (sm *StateMachine) ProposeTransitions(transitions []hdb.Transition) (*hdb.J
 
 	for _, t := range transitions {
 
+		err = t.Enrich(sm.jsonState.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("transition enrichment failed: %s", err)
+		}
+
 		err = t.Validate(jsonStateBranch.Bytes())
 		if err != nil {
 			return nil, fmt.Errorf("transition validation failed: %s", err)

--- a/internal/node/hdb/types.go
+++ b/internal/node/hdb/types.go
@@ -20,8 +20,18 @@ type TransitionWrapper struct {
 }
 
 type Transition interface {
+	// Type returns a string constant identifying the type of state transition. Currently these are in snake case.
 	Type() string
+
+	// Patch takes the old state and returns a JSON patch to apply to the old state to get the new state.
 	Patch(oldState []byte) ([]byte, error)
+
+	// Enrich adds important data to the transition that is not specified when submitted by the client.
+	// For example, the id of a newly created object can be generated during the enrichment phase. The id is not
+	// something we'd want the client to submit, but we want it to be included in the transition.
+	Enrich(oldState []byte) error
+
+	// Validate checks that the transition is valid given the old state.
 	Validate(oldState []byte) error
 }
 

--- a/internal/node/hdb/types.go
+++ b/internal/node/hdb/types.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 )
 
+// Aliases for serialized types.
+type SerializedState []byte
+
 type Schema interface {
 	Name() string
 	EmptyState() (State, error)
@@ -24,18 +27,18 @@ type Transition interface {
 	Type() string
 
 	// Patch takes the old state and returns a JSON patch to apply to the old state to get the new state.
-	Patch(oldState []byte) ([]byte, error)
+	Patch(oldState SerializedState) (SerializedState, error)
 
 	// Enrich adds important data to the transition that is not specified when submitted by the client.
 	// For example, the id of a newly created object can be generated during the enrichment phase. The id is not
 	// something we'd want the client to submit, but we want it to be included in the transition.
-	Enrich(oldState []byte) error
+	Enrich(oldState SerializedState) error
 
 	// Validate checks that the transition is valid given the old state.
-	Validate(oldState []byte) error
+	Validate(oldState SerializedState) error
 }
 
-func WrapTransition(t Transition, patch []byte, oldState []byte) (*TransitionWrapper, error) {
+func WrapTransition(t Transition, patch []byte, oldState SerializedState) (*TransitionWrapper, error) {
 
 	transition, err := json.Marshal(t)
 	if err != nil {

--- a/internal/node/package_manager/restore.go
+++ b/internal/node/package_manager/restore.go
@@ -9,7 +9,7 @@ type PackageManagerRestorer struct {
 	packageManager PackageManager
 }
 
-func (r *PackageManagerRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
+func (r *PackageManagerRestorer) Restore(restoreEvent hdb.StateUpdate) error {
 	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, app := range nodeState.AppInstallations {
 		// Only try to install the app if it was in the state "installing"

--- a/internal/node/package_manager/restore.go
+++ b/internal/node/package_manager/restore.go
@@ -10,7 +10,7 @@ type PackageManagerRestorer struct {
 }
 
 func (r *PackageManagerRestorer) Restore(restoreEvent hdb.StateUpdate) error {
-	nodeState := restoreEvent.NewState().(*node.NodeState)
+	nodeState := restoreEvent.NewState().(*node.State)
 	for _, app := range nodeState.AppInstallations {
 		// Only try to install the app if it was in the state "installing"
 		if app.State == node.AppLifecycleStateInstalling {

--- a/internal/node/package_manager/restore.go
+++ b/internal/node/package_manager/restore.go
@@ -1,8 +1,6 @@
 package package_manager
 
 import (
-	"encoding/json"
-
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 )
@@ -11,17 +9,12 @@ type PackageManagerRestorer struct {
 	packageManager PackageManager
 }
 
-func (r *PackageManagerRestorer) Restore(restoreEvent *hdb.StateUpdate) error {
-	var nodeState node.NodeState
-	err := json.Unmarshal(restoreEvent.NewState, &nodeState)
-	if err != nil {
-		return err
-	}
-
+func (r *PackageManagerRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
+	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, app := range nodeState.AppInstallations {
 		// Only try to install the app if it was in the state "installing"
 		if app.State == node.AppLifecycleStateInstalling {
-			err = r.packageManager.InstallPackage(&app.Package, app.Version)
+			err := r.packageManager.InstallPackage(&app.Package, app.Version)
 			if err != nil {
 				return err
 			}

--- a/internal/node/package_manager/restore_test.go
+++ b/internal/node/package_manager/restore_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRestore(t *testing.T) {
-	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.NodeState{
+	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.State{
 		Users: map[string]*node.User{
 			"user1": {
 				ID: "user1",

--- a/internal/node/package_manager/subscriber.go
+++ b/internal/node/package_manager/subscriber.go
@@ -17,9 +17,9 @@ func (e *InstallAppExecutor) TransitionType() string {
 	return node.TransitionStartInstallation
 }
 
-func (e *InstallAppExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, error) {
+func (e *InstallAppExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
 	var t node.StartInstallationTransition
-	err := json.Unmarshal(update.Transition, &t)
+	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
 		return false, err
 	}
@@ -35,9 +35,9 @@ func (e *InstallAppExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, error
 	return true, nil
 }
 
-func (e *InstallAppExecutor) Execute(update *hdb.StateUpdate) error {
+func (e *InstallAppExecutor) Execute(update hdb.StateUpdateInternal) error {
 	var t node.StartInstallationTransition
-	err := json.Unmarshal(update.Transition, &t)
+	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
 		return err
 	}
@@ -49,9 +49,9 @@ func (e *InstallAppExecutor) Execute(update *hdb.StateUpdate) error {
 	return nil
 }
 
-func (e *InstallAppExecutor) PostHook(update *hdb.StateUpdate) error {
+func (e *InstallAppExecutor) PostHook(update hdb.StateUpdateInternal) error {
 	var t node.StartInstallationTransition
-	err := json.Unmarshal(update.Transition, &t)
+	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
 		return err
 	}

--- a/internal/node/package_manager/subscriber.go
+++ b/internal/node/package_manager/subscriber.go
@@ -17,7 +17,7 @@ func (e *InstallAppExecutor) TransitionType() string {
 	return node.TransitionStartInstallation
 }
 
-func (e *InstallAppExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
+func (e *InstallAppExecutor) ShouldExecute(update hdb.StateUpdate) (bool, error) {
 	var t node.StartInstallationTransition
 	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
@@ -35,7 +35,7 @@ func (e *InstallAppExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool
 	return true, nil
 }
 
-func (e *InstallAppExecutor) Execute(update hdb.StateUpdateInternal) error {
+func (e *InstallAppExecutor) Execute(update hdb.StateUpdate) error {
 	var t node.StartInstallationTransition
 	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
@@ -49,7 +49,7 @@ func (e *InstallAppExecutor) Execute(update hdb.StateUpdateInternal) error {
 	return nil
 }
 
-func (e *InstallAppExecutor) PostHook(update hdb.StateUpdateInternal) error {
+func (e *InstallAppExecutor) PostHook(update hdb.StateUpdate) error {
 	var t node.StartInstallationTransition
 	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
@@ -76,15 +76,16 @@ func (e *FinishInstallExecutor) TransitionType() string {
 	return node.TransitionFinishInstallation
 }
 
-func (e *FinishInstallExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
+func (e *FinishInstallExecutor) ShouldExecute(update hdb.StateUpdate) (bool, error) {
 	return true, nil
 }
 
-func (e *FinishInstallExecutor) Execute(update hdb.StateUpdateInternal) error {
+func (e *FinishInstallExecutor) Execute(update hdb.StateUpdate) error {
+	// noop
 	return nil
 }
 
-func (e *FinishInstallExecutor) PostHook(update hdb.StateUpdateInternal) error {
+func (e *FinishInstallExecutor) PostHook(update hdb.StateUpdate) error {
 	var t node.FinishInstallationTransition
 	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {

--- a/internal/node/package_manager/subscriber.go
+++ b/internal/node/package_manager/subscriber.go
@@ -67,7 +67,6 @@ func (e *InstallAppExecutor) PostHook(update hdb.StateUpdate) error {
 }
 
 // FinishInstallExecutor is a state update executor that finishes the installation of an application.
-// Currently it is just run for it's PostHook, which will try to start the app if StartAfterInstallation is set.
 type FinishInstallExecutor struct {
 	nodeController controller.NodeController
 }
@@ -81,11 +80,6 @@ func (e *FinishInstallExecutor) ShouldExecute(update hdb.StateUpdate) (bool, err
 }
 
 func (e *FinishInstallExecutor) Execute(update hdb.StateUpdate) error {
-	// noop
-	return nil
-}
-
-func (e *FinishInstallExecutor) PostHook(update hdb.StateUpdate) error {
 	var t node.FinishInstallationTransition
 	err := json.Unmarshal(update.Transition(), &t)
 	if err != nil {
@@ -99,6 +93,11 @@ func (e *FinishInstallExecutor) PostHook(update hdb.StateUpdate) error {
 		}
 	}
 
+	return nil
+}
+
+func (e *FinishInstallExecutor) PostHook(update hdb.StateUpdate) error {
+	// noop
 	return nil
 }
 

--- a/internal/node/package_manager/subscriber.go
+++ b/internal/node/package_manager/subscriber.go
@@ -57,7 +57,8 @@ func (e *InstallAppExecutor) PostHook(update hdb.StateUpdateInternal) error {
 	}
 
 	// After finishing the installation, update the application's lifecycle state
-	err = e.nodeController.FinishAppInstallation(t.UserID, t.AppInstallation.ID, t.RegistryURLBase, t.RegistryPackageID)
+	appInstallation := t.EnrichedData.AppState
+	err = e.nodeController.FinishAppInstallation(t.UserID, appInstallation.ID, appInstallation.RegistryURLBase, appInstallation.RegistryPackageID)
 	if err != nil {
 		return err
 	}

--- a/internal/node/package_manager/subscriber_test.go
+++ b/internal/node/package_manager/subscriber_test.go
@@ -28,7 +28,7 @@ func TestAppInstallSubscriber(t *testing.T) {
 				},
 			},
 		},
-		&node.NodeState{
+		&node.State{
 			Users: map[string]*node.User{
 				"user1": {
 					ID: "user1",
@@ -113,7 +113,7 @@ func TestFinishInstallSubscriber(t *testing.T) {
 			RegistryAppID:          "package1",
 			StartAfterInstallation: true,
 		},
-		&node.NodeState{
+		&node.State{
 			Users: map[string]*node.User{
 				"user1": {
 					ID: "user1",
@@ -172,7 +172,7 @@ func TestFinishInstallSubscriberNoAutoStart(t *testing.T) {
 			RegistryAppID:          "package1",
 			StartAfterInstallation: false,
 		},
-		&node.NodeState{
+		&node.State{
 			Users: map[string]*node.User{
 				"user1": {
 					ID: "user1",

--- a/internal/node/package_manager/subscriber_test.go
+++ b/internal/node/package_manager/subscriber_test.go
@@ -84,7 +84,7 @@ func TestSubscriber(t *testing.T) {
 	err = installAppExecutor.Execute(stateUpdate)
 	assert.Nil(t, err)
 
-	nc.EXPECT().FinishAppInstallation(gomock.Eq("user1"), gomock.Any(), gomock.Eq("registry.com"), gomock.Eq("package1")).Return(nil).Times(2)
+	nc.EXPECT().FinishAppInstallation(gomock.Eq("user1"), gomock.Any(), gomock.Eq("registry.com"), gomock.Eq("package1"), false).Return(nil).Times(2)
 
 	err = installAppExecutor.PostHook(stateUpdate)
 	assert.Nil(t, err)

--- a/internal/node/package_manager/subscriber_test.go
+++ b/internal/node/package_manager/subscriber_test.go
@@ -155,12 +155,10 @@ func TestFinishInstallSubscriber(t *testing.T) {
 	assert.Equal(t, true, should)
 
 	// Test that executing is a no-op
+	nc.EXPECT().StartProcess(gomock.Eq("app1")).Return(nil).Times(1)
 	err = finishAppInstallExecutor.Execute(stateUpdate)
 	assert.Nil(t, err)
 
-	// Test that we start the process.
-
-	nc.EXPECT().StartProcess(gomock.Eq("app1")).Return(nil).Times(1)
 	err = finishAppInstallExecutor.PostHook(stateUpdate)
 	assert.Nil(t, err)
 }
@@ -215,13 +213,12 @@ func TestFinishInstallSubscriberNoAutoStart(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, true, should)
 
-	// Test that executing is a no-op
+	nc.EXPECT().StartProcess(gomock.Eq("app1")).Return(nil).Times(0)
 	err = finishAppInstallExecutor.Execute(stateUpdate)
 	assert.Nil(t, err)
 
 	// Test that we start the process.
 
-	nc.EXPECT().StartProcess(gomock.Eq("app1")).Return(nil).Times(0)
 	err = finishAppInstallExecutor.PostHook(stateUpdate)
 	assert.Nil(t, err)
 }

--- a/internal/node/processes/restore.go
+++ b/internal/node/processes/restore.go
@@ -1,8 +1,6 @@
 package processes
 
 import (
-	"encoding/json"
-
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/controller"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
@@ -14,13 +12,9 @@ type ProcessRestorer struct {
 	nodeController controller.NodeController
 }
 
-func (r *ProcessRestorer) Restore(restoreEvent *hdb.StateUpdate) error {
-	var nodeState node.NodeState
-	err := json.Unmarshal(restoreEvent.NewState, &nodeState)
-	if err != nil {
-		return err
-	}
+func (r *ProcessRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
 
+	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, process := range nodeState.Processes {
 		app, err := nodeState.GetAppByID(process.AppID)
 		if err != nil {

--- a/internal/node/processes/restore.go
+++ b/internal/node/processes/restore.go
@@ -12,7 +12,7 @@ type ProcessRestorer struct {
 	nodeController controller.NodeController
 }
 
-func (r *ProcessRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
+func (r *ProcessRestorer) Restore(restoreEvent hdb.StateUpdate) error {
 
 	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, process := range nodeState.Processes {

--- a/internal/node/processes/restore.go
+++ b/internal/node/processes/restore.go
@@ -14,7 +14,7 @@ type ProcessRestorer struct {
 
 func (r *ProcessRestorer) Restore(restoreEvent hdb.StateUpdate) error {
 
-	nodeState := restoreEvent.NewState().(*node.NodeState)
+	nodeState := restoreEvent.NewState().(*node.State)
 	for _, process := range nodeState.Processes {
 		app, err := nodeState.GetAppByID(process.AppID)
 		if err != nil {

--- a/internal/node/processes/restore_test.go
+++ b/internal/node/processes/restore_test.go
@@ -28,7 +28,7 @@ func TestProcessRestorer(t *testing.T) {
 		nodeController: nc,
 	}
 
-	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.NodeState{
+	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.State{
 		Users: map[string]*node.User{
 			"user1": {
 				ID: "user1",

--- a/internal/node/processes/subscriber.go
+++ b/internal/node/processes/subscriber.go
@@ -24,7 +24,7 @@ func (e *StartProcessExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bo
 		return false, err
 	}
 
-	_, err = e.processManager.GetProcess(processStartTransition.Process.ID)
+	_, err = e.processManager.GetProcess(processStartTransition.EnrichedData.Process.ID)
 	if err != nil {
 		return true, nil
 	}
@@ -39,12 +39,19 @@ func (e *StartProcessExecutor) Execute(update hdb.StateUpdateInternal) error {
 		return err
 	}
 
-	err = e.processManager.StartProcess(processStartTransition.Process, processStartTransition.App)
+	nodeState := update.NewState().(*node.NodeState)
+
+	app, err := nodeState.GetAppByID(processStartTransition.AppID)
 	if err != nil {
 		return err
 	}
 
-	err = e.nodeController.SetProcessRunning(processStartTransition.Process.ID)
+	err = e.processManager.StartProcess(processStartTransition.EnrichedData.Process.Process, app.AppInstallation)
+	if err != nil {
+		return err
+	}
+
+	err = e.nodeController.SetProcessRunning(processStartTransition.EnrichedData.Process.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/node/processes/subscriber.go
+++ b/internal/node/processes/subscriber.go
@@ -39,7 +39,7 @@ func (e *StartProcessExecutor) Execute(update hdb.StateUpdate) error {
 		return err
 	}
 
-	nodeState := update.NewState().(*node.NodeState)
+	nodeState := update.NewState().(*node.State)
 
 	app, err := nodeState.GetAppByID(processStartTransition.AppID)
 	if err != nil {

--- a/internal/node/processes/subscriber.go
+++ b/internal/node/processes/subscriber.go
@@ -17,7 +17,7 @@ func (e *StartProcessExecutor) TransitionType() string {
 	return node.TransitionStartProcess
 }
 
-func (e *StartProcessExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
+func (e *StartProcessExecutor) ShouldExecute(update hdb.StateUpdate) (bool, error) {
 	var processStartTransition node.ProcessStartTransition
 	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
@@ -32,7 +32,7 @@ func (e *StartProcessExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bo
 	return false, nil
 }
 
-func (e *StartProcessExecutor) Execute(update hdb.StateUpdateInternal) error {
+func (e *StartProcessExecutor) Execute(update hdb.StateUpdate) error {
 	var processStartTransition node.ProcessStartTransition
 	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
@@ -59,6 +59,6 @@ func (e *StartProcessExecutor) Execute(update hdb.StateUpdateInternal) error {
 	return nil
 }
 
-func (e *StartProcessExecutor) PostHook(update hdb.StateUpdateInternal) error {
+func (e *StartProcessExecutor) PostHook(update hdb.StateUpdate) error {
 	return nil
 }

--- a/internal/node/processes/subscriber.go
+++ b/internal/node/processes/subscriber.go
@@ -17,9 +17,9 @@ func (e *StartProcessExecutor) TransitionType() string {
 	return node.TransitionStartProcess
 }
 
-func (e *StartProcessExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, error) {
+func (e *StartProcessExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
 	var processStartTransition node.ProcessStartTransition
-	err := json.Unmarshal(update.Transition, &processStartTransition)
+	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
 		return false, err
 	}
@@ -32,9 +32,9 @@ func (e *StartProcessExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, err
 	return false, nil
 }
 
-func (e *StartProcessExecutor) Execute(update *hdb.StateUpdate) error {
+func (e *StartProcessExecutor) Execute(update hdb.StateUpdateInternal) error {
 	var processStartTransition node.ProcessStartTransition
-	err := json.Unmarshal(update.Transition, &processStartTransition)
+	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
 		return err
 	}
@@ -52,6 +52,6 @@ func (e *StartProcessExecutor) Execute(update *hdb.StateUpdate) error {
 	return nil
 }
 
-func (e *StartProcessExecutor) PostHook(update *hdb.StateUpdate) error {
+func (e *StartProcessExecutor) PostHook(update hdb.StateUpdateInternal) error {
 	return nil
 }

--- a/internal/node/processes/subscriber_test.go
+++ b/internal/node/processes/subscriber_test.go
@@ -28,7 +28,7 @@ func TestSubscriber(t *testing.T) {
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
 		AppID: "app1",
-	}, &node.NodeState{
+	}, &node.State{
 		AppInstallations: map[string]*node.AppInstallationState{
 			"app1": {
 				AppInstallation: &node.AppInstallation{

--- a/internal/node/processes/subscriber_test.go
+++ b/internal/node/processes/subscriber_test.go
@@ -8,6 +8,7 @@ import (
 	ctrl_mocks "github.com/eagraf/habitat-new/internal/node/controller/mocks"
 	"github.com/eagraf/habitat-new/internal/node/processes/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -26,18 +27,19 @@ func TestSubscriber(t *testing.T) {
 	}
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
-		Process: &node.Process{
-			ID:     "proc1",
-			Driver: "test",
-		},
-		App: &node.AppInstallation{
-			ID:   "app1",
-			Name: "appname1",
-			Package: node.Package{
-				Driver: "test",
+		AppID: "app1",
+	}, &node.NodeState{
+		AppInstallations: map[string]*node.AppInstallationState{
+			"app1": {
+				AppInstallation: &node.AppInstallation{
+					UserID: "0",
+					ID:     "app1",
+					Package: node.Package{
+						Driver: "test",
+					},
+				},
 			},
 		},
-	}, &node.NodeState{
 		Processes: map[string]*node.ProcessState{},
 	})
 	assert.Nil(t, err)
@@ -46,25 +48,18 @@ func TestSubscriber(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, true, shouldExecute)
 
-	mockDriver.EXPECT().StartProcess(
-		gomock.Eq(
-			&node.Process{
-				ID:     "proc1",
-				Driver: "test",
-			},
-		),
-		gomock.Eq(
-			&node.AppInstallation{
-				ID:   "app1",
-				Name: "appname1",
-				Package: node.Package{
-					Driver: "test",
-				},
-			},
-		),
-	).Return("ext_proc1", nil)
+	mockDriver.EXPECT().StartProcess(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(process *node.Process, app *node.AppInstallation) (string, error) {
+			require.Equal(t, "app1", process.AppID)
+			require.Equal(t, "0", process.UserID)
 
-	nc.EXPECT().SetProcessRunning("proc1").Return(nil)
+			require.Equal(t, "test", app.Package.Driver)
+
+			return "ext_proc1", nil
+		},
+	)
+
+	nc.EXPECT().SetProcessRunning(gomock.Any()).Return(nil)
 
 	err = startProcessExecutor.Execute(startProcessStateUpdate)
 	assert.Nil(t, err)

--- a/internal/node/pubsub/pubsub_test.go
+++ b/internal/node/pubsub/pubsub_test.go
@@ -36,9 +36,9 @@ func TestSimpleChannel(t *testing.T) {
 		consumedEvents: make([]*TestEvent, 0),
 	}
 
-	sp := NewSimplePublisher[TestEvent]()
+	sp := NewSimplePublisher[*TestEvent]()
 
-	channel := NewSimpleChannel[TestEvent]([]Publisher[TestEvent]{sp}, []Subscriber[TestEvent]{subscriber1, subscriber2})
+	channel := NewSimpleChannel[*TestEvent]([]Publisher[*TestEvent]{sp}, []Subscriber[*TestEvent]{subscriber1, subscriber2})
 	go func() {
 		err := channel.Listen()
 		if err != nil {

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -1,8 +1,6 @@
 package reverse_proxy
 
 import (
-	"encoding/json"
-
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/rs/zerolog/log"
@@ -12,13 +10,8 @@ type ReverseProxyRestorer struct {
 	ruleSet RuleSet
 }
 
-func (r *ReverseProxyRestorer) Restore(restoreEvent *hdb.StateUpdate) error {
-	var nodeState node.NodeState
-	err := json.Unmarshal(restoreEvent.NewState, &nodeState)
-	if err != nil {
-		return err
-	}
-
+func (r *ReverseProxyRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
+	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, process := range nodeState.Processes {
 		rules, err := nodeState.GetReverseProxyRulesForProcess(process.ID)
 		if err != nil {

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -10,7 +10,7 @@ type ReverseProxyRestorer struct {
 	ruleSet RuleSet
 }
 
-func (r *ReverseProxyRestorer) Restore(restoreEvent hdb.StateUpdateInternal) error {
+func (r *ReverseProxyRestorer) Restore(restoreEvent hdb.StateUpdate) error {
 	nodeState := restoreEvent.NewState().(*node.NodeState)
 	for _, process := range nodeState.Processes {
 		rules, err := nodeState.GetReverseProxyRulesForProcess(process.ID)

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -11,7 +11,7 @@ type ReverseProxyRestorer struct {
 }
 
 func (r *ReverseProxyRestorer) Restore(restoreEvent hdb.StateUpdate) error {
-	nodeState := restoreEvent.NewState().(*node.NodeState)
+	nodeState := restoreEvent.NewState().(*node.State)
 	for _, process := range nodeState.Processes {
 		rules, err := nodeState.GetReverseProxyRulesForProcess(process.ID)
 		if err != nil {

--- a/internal/node/reverse_proxy/restore_test.go
+++ b/internal/node/reverse_proxy/restore_test.go
@@ -15,7 +15,7 @@ func TestProcessRestorer(t *testing.T) {
 		ruleSet: ruleSet,
 	}
 
-	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.NodeState{
+	restoreUpdate, err := test_helpers.StateUpdateTestHelper(&node.InitalizationTransition{}, &node.State{
 		Users: map[string]*node.User{
 			"user1": {
 				ID: "user1",

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -16,26 +16,20 @@ func (e *ProcessProxyRulesExecutor) TransitionType() string {
 	return node.TransitionStartProcess
 }
 
-func (e *ProcessProxyRulesExecutor) ShouldExecute(update *hdb.StateUpdate) (bool, error) {
+func (e *ProcessProxyRulesExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
 	// This process is very lightweight, so we can just execute it every time
 	return true, nil
 }
 
-func (e *ProcessProxyRulesExecutor) Execute(update *hdb.StateUpdate) error {
+func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdateInternal) error {
 	var processStartTransition node.ProcessStartTransition
-	err := json.Unmarshal(update.Transition, &processStartTransition)
+	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
 		return err
 	}
 
-	// Get the node state
-	var state node.NodeState
-	err = json.Unmarshal(update.NewState, &state)
-	if err != nil {
-		return err
-	}
-
-	for _, rule := range *state.ReverseProxyRules {
+	nodeState := update.NewState().(*node.NodeState)
+	for _, rule := range *nodeState.ReverseProxyRules {
 		if rule.AppID == processStartTransition.AppID {
 			log.Info().Msgf("Adding reverse proxy rule %v", rule)
 			err = e.RuleSet.AddRule(rule)
@@ -50,6 +44,6 @@ func (e *ProcessProxyRulesExecutor) Execute(update *hdb.StateUpdate) error {
 
 // TODO remove rule when process is stopped
 
-func (e *ProcessProxyRulesExecutor) PostHook(update *hdb.StateUpdate) error {
+func (e *ProcessProxyRulesExecutor) PostHook(update hdb.StateUpdateInternal) error {
 	return nil
 }

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -28,7 +28,7 @@ func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdate) error {
 		return err
 	}
 
-	nodeState := update.NewState().(*node.NodeState)
+	nodeState := update.NewState().(*node.State)
 	for _, rule := range *nodeState.ReverseProxyRules {
 		if rule.AppID == processStartTransition.AppID {
 			log.Info().Msgf("Adding reverse proxy rule %v", rule)

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -16,12 +16,12 @@ func (e *ProcessProxyRulesExecutor) TransitionType() string {
 	return node.TransitionStartProcess
 }
 
-func (e *ProcessProxyRulesExecutor) ShouldExecute(update hdb.StateUpdateInternal) (bool, error) {
+func (e *ProcessProxyRulesExecutor) ShouldExecute(update hdb.StateUpdate) (bool, error) {
 	// This process is very lightweight, so we can just execute it every time
 	return true, nil
 }
 
-func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdateInternal) error {
+func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdate) error {
 	var processStartTransition node.ProcessStartTransition
 	err := json.Unmarshal(update.Transition(), &processStartTransition)
 	if err != nil {
@@ -44,6 +44,6 @@ func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdateInternal) erro
 
 // TODO remove rule when process is stopped
 
-func (e *ProcessProxyRulesExecutor) PostHook(update hdb.StateUpdateInternal) error {
+func (e *ProcessProxyRulesExecutor) PostHook(update hdb.StateUpdate) error {
 	return nil
 }

--- a/internal/node/reverse_proxy/subscriber_test.go
+++ b/internal/node/reverse_proxy/subscriber_test.go
@@ -15,7 +15,7 @@ func TestSubscriber(t *testing.T) {
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
 		AppID: "app1",
-	}, &node.NodeState{
+	}, &node.State{
 		AppInstallations: map[string]*node.AppInstallationState{
 			"app1": {
 				AppInstallation: &node.AppInstallation{
@@ -64,7 +64,7 @@ func TestBrokenRule(t *testing.T) {
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
 		AppID: "app1",
-	}, &node.NodeState{
+	}, &node.State{
 		AppInstallations: map[string]*node.AppInstallationState{
 			"app1": {
 				AppInstallation: &node.AppInstallation{

--- a/internal/node/reverse_proxy/subscriber_test.go
+++ b/internal/node/reverse_proxy/subscriber_test.go
@@ -14,18 +14,7 @@ func TestSubscriber(t *testing.T) {
 	}
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
-		Process: &node.Process{
-			ID:     "proc1",
-			Driver: "test",
-			AppID:  "app1",
-		},
-		App: &node.AppInstallation{
-			ID:   "app1",
-			Name: "appname1",
-			Package: node.Package{
-				Driver: "test",
-			},
-		},
+		AppID: "app1",
 	}, &node.NodeState{
 		AppInstallations: map[string]*node.AppInstallationState{
 			"app1": {
@@ -74,18 +63,7 @@ func TestBrokenRule(t *testing.T) {
 	}
 
 	startProcessStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.ProcessStartTransition{
-		Process: &node.Process{
-			ID:     "proc1",
-			Driver: "test",
-			AppID:  "app1",
-		},
-		App: &node.AppInstallation{
-			ID:   "app1",
-			Name: "appname1",
-			Package: node.Package{
-				Driver: "test",
-			},
-		},
+		AppID: "app1",
 	}, &node.NodeState{
 		AppInstallations: map[string]*node.AppInstallationState{
 			"app1": {


### PR DESCRIPTION
This PR has two refactors to state management, and then a change for starting the PDS automatically after it has been installed. There are also some changes to get development working on Linux.

1. Previously, `StateUpdate` only stored serialized JSON for the new state, as well as the state transition, which led to repeated bits of deserialization code sprinkled across all of our state update subscribers. This was refactored to have deserialization occur before the state update is sent to the subscribers, using the `StateUpdateInternal` interface.

2. Add an `Enrich` method to `Transition`. This allows for the system to populate data into the proposed state transition that was not specified by the client. This is helpful for generating timestamps and UUIDs, as well as denormalizing some contextual data into the transition data structure for easy access in downstream businesss logic.
