### PR TITLE
Eagraf/support extension

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,20 +1,30 @@
 'use client'
 
-import React, { useState, FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import React, { useState, FormEvent, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import './login.css';
 import { useAuth } from '@/components/authContext';
 
-const Login = () => {
+const LoginInternal = () => {
     const [handle, setHandle] = useState('');
     const [password, setPassword] = useState('');
     const { login } = useAuth();
 
-    const router = useRouter();
+    useRouter();
+
+    const searchParams = useSearchParams();
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        let redirectRoute: string = '/home';
+        const overrideRoute =  searchParams.get('redirectRoute');
+        if (overrideRoute) {
+            redirectRoute = overrideRoute;
+        }
+
+        const source = searchParams.get('source');
+
         event.preventDefault();
-        login(handle, password);
+        login(handle, password, redirectRoute, source);
     };
 
     return (
@@ -44,6 +54,14 @@ const Login = () => {
                 <button type="submit">Login</button>
             </form>
         </div>
+    );
+};
+
+const Login = () => {
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            <LoginInternal />
+        </Suspense>
     );
 };
 

--- a/frontend/components/withAuth.tsx
+++ b/frontend/components/withAuth.tsx
@@ -12,7 +12,6 @@ const withAuth = (WrappedComponent: React.FC) => {
         useEffect(() => {
             console.log(isAuthenticated);
             if (!isAuthenticated) {
-                console.log("pusho");
                 router.push('/login');
             }
         }, [isAuthenticated, router]);

--- a/internal/node/drivers/docker/driver.go
+++ b/internal/node/drivers/docker/driver.go
@@ -68,7 +68,7 @@ func (d *AppDriver) Driver() string {
 
 func (d *AppDriver) IsInstalled(packageSpec *node.Package, version string) (bool, error) {
 	// TODO review all contexts we create.
-	repoURL := repoURLFromPackage(packageSpec, version)
+	repoURL := repoURLFromPackage(packageSpec)
 	images, err := d.client.ImageList(context.Background(), types.ImageListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("reference", repoURL),
@@ -86,7 +86,7 @@ func (d *AppDriver) InstallPackage(packageSpec *node.Package, version string) er
 		return fmt.Errorf("invalid package driver: %s, expected docker", packageSpec.Driver)
 	}
 
-	repoURL := repoURLFromPackage(packageSpec, version)
+	repoURL := repoURLFromPackage(packageSpec)
 	_, err := d.client.ImagePull(context.Background(), repoURL, types.ImagePullOptions{})
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (d *AppDriver) InstallPackage(packageSpec *node.Package, version string) er
 }
 
 func (d *AppDriver) UninstallPackage(packageURL *node.Package, version string) error {
-	repoURL := repoURLFromPackage(packageURL, version)
+	repoURL := repoURLFromPackage(packageURL)
 	_, err := d.client.ImageRemove(context.Background(), repoURL, types.ImageRemoveOptions{})
 	if err != nil {
 		return err

--- a/internal/node/drivers/docker/helpers.go
+++ b/internal/node/drivers/docker/helpers.go
@@ -6,6 +6,6 @@ import (
 	"github.com/eagraf/habitat-new/core/state/node"
 )
 
-func repoURLFromPackage(packageSpec *node.Package, version string) string {
-	return fmt.Sprintf("%s/%s:%s", packageSpec.RegistryURLBase, packageSpec.RegistryPackageID, version)
+func repoURLFromPackage(packageSpec *node.Package) string {
+	return fmt.Sprintf("%s/%s:%s", packageSpec.RegistryURLBase, packageSpec.RegistryPackageID, packageSpec.RegistryPackageTag)
 }


### PR DESCRIPTION
Some small changes to the auth flow that support the fork of pouch I've been working on:
- Fixed a bug in the docker driver generating the identifier for docker images (unrelated, but needed for testing)
- Set additional cookies for user DID, node hostname, and additional chrome extension cookies. These allow the extension to both authenticate with the node, and figure out how to reach it.