### PR TITLE
QOL improvements to testing migrations

### DIFF
--- a/core/state/node/migrations_test.go
+++ b/core/state/node/migrations_test.go
@@ -11,11 +11,23 @@ import (
 )
 
 func TestSchemaMigrations(t *testing.T) {
+	// Test applying all migrations one at a time, and make sure the finalresult
+	// matches the schema.json file. Then go back down, and make sure we start
+	// from the same initial empty state.
 	err := validateSchemaMigrations()
-	assert.Nil(t, err)
+	if err != nil {
+		t.Error(err)
+	}
 
+	// Test migrating directly to the latest version. This path is more similar to
+	// what the node will actually execute.
+	//
+	// NOTE: if this test is failing, check that the LatestVersion reflects the most
+	// recent migrations you have written.
 	err = validateNodeSchemaMigrations(LatestVersion)
-	assert.Nil(t, err)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Test non-existant high version
 	err = validateNodeSchemaMigrations("v1000.0.1")


### PR DESCRIPTION
When testing our schema migrations, we make sure the list of migrations applied on top of each other results in the exact same result as the `schema.json` file. 

This just ensures that the output showing the diffs between the expected and actual result schemas is printed clearly with proper indentation and no escapes, so it's easy to read, which makes debugging issues with this critical test a lot faster.