### PR TITLE
Eagraf/refactor reverse proxy

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	proxy := reverse_proxy.NewProxyServer(logger, nodeConfig)
 
-	proxyRuleStateUpdateSubscriber, err := reverse_proxy.NewProcessProxyRuleStateUpdateSubscriber(
+	proxyRuleStateUpdateSubscriber, err := reverse_proxy.NewProcessProxyRuleSubscriber(
 		proxy.RuleSet,
 	)
 	if err != nil {

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os/signal"
 	"syscall"
 
-	"github.com/eagraf/habitat-new/internal/frontend"
 	"github.com/eagraf/habitat-new/internal/node/api"
 	"github.com/eagraf/habitat-new/internal/node/config"
 	"github.com/eagraf/habitat-new/internal/node/constants"
@@ -153,17 +151,6 @@ func main() {
 		Addr:    fmt.Sprintf(":%s", constants.DefaultPortHabitatAPI),
 		Handler: router,
 	}
-	url, err := url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
-	if err != nil {
-		log.Fatal().Err(fmt.Errorf("error parsing Habitat API URL: %v", err)).Msg("error parsing Habitat API URL")
-	}
-	err = proxy.RuleSet.Add("Habitat API", &reverse_proxy.RedirectRule{
-		ForwardLocation: url,
-		Matcher:         "/habitat/api",
-	})
-	if err != nil {
-		log.Fatal().Err(fmt.Errorf("error adding Habitat API proxy rule: %v", err)).Msg("error adding Habitat API proxy rule")
-	}
 	eg.Go(
 		server.ServeFn(
 			apiServer,
@@ -171,16 +158,6 @@ func main() {
 			server.WithTLSConfig(tlsConfig, nodeConfig.NodeCertPath(), nodeConfig.NodeKeyPath()),
 		),
 	)
-
-	frontendProxyRule, err := frontend.NewFrontendProxyRule(nodeConfig)
-	if err != nil {
-		log.Fatal().Err(fmt.Errorf("error getting frontend proxy rule: %v", err)).Msg("error getting frontend proxy rule")
-	}
-
-	err = proxy.RuleSet.Add("Frontend", frontendProxyRule)
-	if err != nil {
-		log.Fatal().Err(fmt.Errorf("error adding frontend proxy rule: %v", err)).Msg("error adding frontend proxy rule")
-	}
 
 	// Wait for either os.Interrupt which triggers ctx.Done()
 	// Or one of the servers to error, which triggers egCtx.Done()

--- a/core/state/node/core.go
+++ b/core/state/node/core.go
@@ -46,15 +46,17 @@ type Process struct {
 // The semantics of the target field changes depending on the type. For file servers, it represents the
 // path to the directory to serve files from. For redirects, it represents the URL to redirect to.
 type ReverseProxyRule struct {
-	ID      string `json:"id" yaml:"id"`
-	Type    string `json:"type" yaml:"type"`
-	Matcher string `json:"matcher" yaml:"matcher"`
-	Target  string `json:"target" yaml:"target"`
-	AppID   string `json:"app_id" yaml:"app_id"`
+	ID      string               `json:"id" yaml:"id"`
+	Type    ReverseProxyRuleType `json:"type" yaml:"type"`
+	Matcher string               `json:"matcher" yaml:"matcher"`
+	Target  string               `json:"target" yaml:"target"`
+	AppID   string               `json:"app_id" yaml:"app_id"`
 }
 
+type ReverseProxyRuleType = string
+
 const (
-	ProxyRuleFileServer       = "file"
-	ProxyRuleRedirect         = "redirect"
-	ProxyRuleEmbeddedFrontend = "embedded_frontend"
+	ProxyRuleFileServer       ReverseProxyRuleType = "file"
+	ProxyRuleRedirect         ReverseProxyRuleType = "redirect"
+	ProxyRuleEmbeddedFrontend ReverseProxyRuleType = "embedded_frontend"
 )

--- a/core/state/node/core.go
+++ b/core/state/node/core.go
@@ -52,3 +52,9 @@ type ReverseProxyRule struct {
 	Target  string `json:"target" yaml:"target"`
 	AppID   string `json:"app_id" yaml:"app_id"`
 }
+
+const (
+	ProxyRuleFileServer       = "file"
+	ProxyRuleRedirect         = "redirect"
+	ProxyRuleEmbeddedFrontend = "embedded_frontend"
+)

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -2,33 +2,7 @@ package frontend
 
 import (
 	"embed"
-	"io/fs"
-	"net/url"
-
-	"github.com/eagraf/habitat-new/internal/node/config"
-	"github.com/eagraf/habitat-new/internal/node/reverse_proxy"
 )
 
 //go:embed build/*
-var frontendBuild embed.FS
-
-func NewFrontendProxyRule(config *config.NodeConfig) (reverse_proxy.RuleHandler, error) {
-	if config.FrontendDev() {
-		feDevServer, _ := url.Parse("http://habitat_frontend:8000/")
-		// The root matcher is empty, so this rule will match all requests that don't have a more specific rule
-		return &reverse_proxy.RedirectRule{
-			Matcher:         "",
-			ForwardLocation: feDevServer,
-		}, nil
-	} else {
-
-		fSys, err := fs.Sub(frontendBuild, "build")
-		if err != nil {
-			return nil, err
-		}
-		return &reverse_proxy.FileServerRule{
-			Matcher: "",
-			FS:      fSys,
-		}, nil
-	}
-}
+var EmbeddedFrontendBundle embed.FS

--- a/internal/node/config/config_test.go
+++ b/internal/node/config/config_test.go
@@ -42,11 +42,13 @@ default_apps:
 `
 
 func TestLoadingDefaultApps(t *testing.T) {
-	viper.SetConfigType("yaml")
-	err := viper.ReadConfig(strings.NewReader(testHabitatYaml))
+	v := viper.New()
+	v.SetConfigType("yaml")
+	err := v.ReadConfig(strings.NewReader(testHabitatYaml))
 	assert.NoError(t, err)
 
-	testNodeConfig := &NodeConfig{}
+	testNodeConfig, err := NewNodeConfigFromViper(v)
+	assert.NoError(t, err)
 
 	defaultApps := testNodeConfig.DefaultApps()
 	assert.Len(t, defaultApps, 1)

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -27,7 +27,7 @@ func setupNodeDBTest(ctrl *gomock.Controller, t *testing.T) (NodeController, *mo
 	mockedManager.EXPECT().CreateDatabase(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		// signature of anonymous function must have the same number of input and output arguments as the mocked method.
 		func(nodeName, schemaName string, initTransitions []hdb.Transition) (hdb.Client, error) {
-			require.Equal(t, 2, len(initTransitions))
+			require.Equal(t, 4, len(initTransitions))
 
 			initStateTransition := initTransitions[0]
 			require.Equal(t, node.TransitionInitialize, initStateTransition.Type())

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -42,11 +41,10 @@ func setupNodeDBTest(ctrl *gomock.Controller, t *testing.T) (NodeController, *mo
 			return mockedClient, nil
 		}).Times(1)
 
-	controller, err := NewNodeController(mockedManager, &config.NodeConfig{
-		RootUserCert: &x509.Certificate{
-			Raw: []byte("root_cert"),
-		},
-	})
+	config, err := config.NewTestNodeConfig(nil)
+	require.Nil(t, err)
+
+	controller, err := NewNodeController(mockedManager, config)
 	controller.pdsClient = mockedPDSClient
 	require.Nil(t, err)
 	err = controller.InitializeNodeDB()

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -85,9 +85,14 @@ func generateDefaultReverseProxyRules(nodeConfig *config.NodeConfig) ([]*node.Re
 		Matcher: "", // Root matcher
 	}
 	if nodeConfig.FrontendDev() {
+		// In development mode, we run the frontend in a separate docker container with hot-reloading.
+		// As a result, all frontend requests must be forwarde to the frontend container.
 		frontendRule.Type = node.ProxyRuleRedirect
 		frontendRule.Target = "http://habitat_frontend:8000/"
 	} else {
+		// In production mode, we embed the frontend into the node binary. That way, we can serve
+		// the frontend without needing to set it up on the host machine.
+		// TODO @eagraf - evaluate the performance implications of this.
 		frontendRule.Type = node.ProxyRuleEmbeddedFrontend
 	}
 

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types/mount"
@@ -73,6 +74,34 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) *types.PostAppRequest {
 	}
 }
 
+func generateDefaultReverseProxyRules(nodeConfig *config.NodeConfig) ([]*node.ReverseProxyRule, error) {
+	apiURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
+	if err != nil {
+		return nil, err
+	}
+
+	frontendRule := &node.ReverseProxyRule{
+		ID:      "default-rule-frontend",
+		Matcher: "", // Root matcher
+	}
+	if nodeConfig.FrontendDev() {
+		frontendRule.Type = node.ProxyRuleRedirect
+		frontendRule.Target = "http://habitat_frontend:8000/"
+	} else {
+		frontendRule.Type = node.ProxyRuleEmbeddedFrontend
+	}
+
+	return []*node.ReverseProxyRule{
+		{
+			ID:      "default-rule-api",
+			Type:    node.ProxyRuleRedirect,
+			Matcher: "/habitat/api",
+			Target:  apiURL.String(),
+		},
+		frontendRule,
+	}, nil
+}
+
 // TODO this is basically a placeholder until we actually have a way of generating
 // the certificate for the node.
 func generateInitState(nodeConfig *config.NodeConfig) (*node.State, error) {
@@ -102,12 +131,26 @@ func initTranstitions(nodeConfig *config.NodeConfig) ([]hdb.Transition, error) {
 		return nil, err
 	}
 
+	// A list of transitions to apply when the node starts up for the first time.
 	transitions := []hdb.Transition{
 		&node.InitalizationTransition{
 			InitState: initState,
 		},
 	}
 
+	// Generate the list of default proxy rules to have available when the node first comes up
+	proxyRules, err := generateDefaultReverseProxyRules(nodeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range proxyRules {
+		transitions = append(transitions, &node.AddReverseProxyRuleTransition{
+			Rule: rule,
+		})
+	}
+
+	// Generate the list of apps to have installed and started when the node first comes up
 	pdsAppConfig := generatePDSAppConfig(nodeConfig)
 	defaultApplications := []*types.PostAppRequest{
 		pdsAppConfig,
@@ -126,5 +169,6 @@ func initTranstitions(nodeConfig *config.NodeConfig) ([]hdb.Transition, error) {
 			StartAfterInstallation: true,
 		})
 	}
+
 	return transitions, nil
 }

--- a/internal/node/controller/init_test.go
+++ b/internal/node/controller/init_test.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/node/config"
+	"github.com/eagraf/habitat-new/internal/node/hdb"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func testTransitions(oldState *node.State, transitions []hdb.Transition) (*node.State, error) {
+	var oldJSONState *hdb.JSONState
+	schema := &node.NodeSchema{}
+	if oldState == nil {
+		emptyState, err := schema.EmptyState()
+		if err != nil {
+			return nil, err
+		}
+		ojs, err := hdb.StateToJSONState(emptyState)
+		if err != nil {
+			return nil, err
+		}
+		oldJSONState = ojs
+	} else {
+		ojs, err := hdb.StateToJSONState(oldState)
+		if err != nil {
+			return nil, err
+		}
+
+		oldJSONState = ojs
+	}
+	for _, t := range transitions {
+		if t.Type() == "" {
+			return nil, fmt.Errorf("transition type is empty")
+		}
+
+		err := t.Enrich(oldJSONState.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("transition enrichment failed: %s", err)
+		}
+
+		err = t.Validate(oldJSONState.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("transition validation failed: %s", err)
+		}
+
+		patch, err := t.Patch(oldJSONState.Bytes())
+		if err != nil {
+			return nil, err
+		}
+
+		newStateBytes, err := oldJSONState.ValidatePatch(patch)
+		if err != nil {
+			return nil, err
+		}
+
+		newState, err := hdb.NewJSONState(schema, newStateBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		oldJSONState = newState
+	}
+
+	var state node.State
+	stateBytes := oldJSONState.Bytes()
+
+	err := json.Unmarshal(stateBytes, &state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &state, nil
+}
+
+func TestInitTransitions(t *testing.T) {
+	config, err := config.NewNodeConfig()
+	require.Nil(t, err)
+
+	transitions, err := initTranstitions(config)
+	require.Nil(t, err)
+
+	require.Equal(t, 4, len(transitions))
+}
+
+func TestFrontendDevMode(t *testing.T) {
+	viper.Set("frontend_dev", true)
+	config, err := config.NewNodeConfig()
+	require.Nil(t, err)
+
+	transitions, err := initTranstitions(config)
+	require.Nil(t, err)
+
+	require.Equal(t, 4, len(transitions))
+
+	newState, err := testTransitions(nil, transitions)
+	require.Nil(t, err)
+
+	frontendRule, ok := (*newState.ReverseProxyRules)["default-rule-frontend"]
+	require.Equal(t, true, ok)
+	require.Equal(t, node.ProxyRuleRedirect, frontendRule.Type)
+}

--- a/internal/node/controller/init_test.go
+++ b/internal/node/controller/init_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -79,7 +80,7 @@ func testTransitions(oldState *node.State, transitions []hdb.Transition) (*node.
 }
 
 func TestInitTransitions(t *testing.T) {
-	config, err := config.NewNodeConfig()
+	config, err := config.NewTestNodeConfig(nil)
 	require.Nil(t, err)
 
 	transitions, err := initTranstitions(config)
@@ -89,9 +90,12 @@ func TestInitTransitions(t *testing.T) {
 }
 
 func TestFrontendDevMode(t *testing.T) {
-	viper.Set("frontend_dev", true)
-	config, err := config.NewNodeConfig()
+	v := viper.New()
+	v.Set("frontend_dev", true)
+	config, err := config.NewTestNodeConfig(v)
 	require.Nil(t, err)
+
+	config.RootUserCert = &x509.Certificate{}
 
 	transitions, err := initTranstitions(config)
 	require.Nil(t, err)

--- a/internal/node/hdb/executor.go
+++ b/internal/node/hdb/executor.go
@@ -116,6 +116,13 @@ func (s *IdempotentStateUpdateSubscriber) Name() string {
 	return s.name
 }
 
+func (s *IdempotentStateUpdateSubscriber) GetExecutor(transitionType string) (IdempotentStateUpdateExecutor, error) {
+	if _, ok := s.executors[transitionType]; !ok {
+		return nil, fmt.Errorf("executor with transition type %s not found", transitionType)
+	}
+	return s.executors[transitionType], nil
+}
+
 func (s *IdempotentStateUpdateSubscriber) ConsumeEvent(event StateUpdate) error {
 	// If the restore flag is set, we restore the entire state rather than processing the individual state update.
 	if event.IsRestore() {

--- a/internal/node/reverse_proxy/handler.go
+++ b/internal/node/reverse_proxy/handler.go
@@ -1,0 +1,146 @@
+package reverse_proxy
+
+import (
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/frontend"
+	"github.com/eagraf/habitat-new/internal/node/config"
+	"github.com/rs/zerolog/log"
+)
+
+func getHandlerFromRule(rule *node.ReverseProxyRule, nodeConfig *config.NodeConfig) (http.Handler, error) {
+	switch rule.Type {
+	case node.ProxyRuleRedirect:
+		return getRedirectHandler(rule)
+	case node.ProxyRuleFileServer:
+		return getFileServerHandler(rule, WithBasePath(nodeConfig.WebBundlePath()))
+
+	case node.ProxyRuleEmbeddedFrontend:
+		fSys, err := fs.Sub(frontend.EmbeddedFrontendBundle, "build")
+		if err != nil {
+			return nil, err
+		}
+
+		return getFileServerHandler(rule, WithFS(fSys))
+	default:
+		return nil, fmt.Errorf("unknown rule type %s", rule.Type)
+	}
+}
+
+func getRedirectHandler(rule *node.ReverseProxyRule) (http.Handler, error) {
+	forwardURL, err := url.Parse(rule.Target)
+	if err != nil {
+		return nil, err
+	}
+
+	target := forwardURL.Host
+
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = forwardURL.Scheme
+			req.URL.Host = target
+
+			// TODO implement globs
+			req.URL.Path = path.Join(
+				forwardURL.Path,
+				strings.TrimPrefix(req.URL.Path, rule.Matcher),
+			)
+		},
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).Dial,
+		},
+		ModifyResponse: func(res *http.Response) error {
+			return nil
+		},
+		ErrorHandler: func(rw http.ResponseWriter, r *http.Request, err error) {
+			log.Error().Err(err).Msg("reverse proxy request forwarding error")
+			_, _ = rw.Write([]byte(err.Error()))
+			rw.WriteHeader(http.StatusInternalServerError)
+		},
+	}, nil
+}
+
+func getFileServerHandler(rule *node.ReverseProxyRule, options ...Option) (http.Handler, error) {
+
+	opts := &FileServerOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &fileServerHandler{
+		Prefix:  rule.Matcher,
+		Path:    rule.Target,
+		options: opts,
+	}, nil
+}
+
+type fileServerHandler struct {
+	Prefix string
+	Path   string
+
+	options *FileServerOptions
+}
+
+func (h *fileServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Try to remove prefix
+	oldPath := r.URL.Path
+	r.URL.Path = strings.TrimPrefix(oldPath, h.Prefix)
+
+	if h.options.EmbeddedFS != nil {
+		// This path is used when we serve from an embedded filesystem
+
+		http.FileServer(http.FS(h.options.EmbeddedFS)).ServeHTTP(w, r)
+
+	} else {
+		// Default path: serve files from a directory.
+
+		path := h.Path
+
+		// If a base path is set, and the path is relative, use that instead
+		if h.options.BasePath != "" && !filepath.IsAbs(h.Path) {
+			path = filepath.Join(h.options.BasePath, h.Path)
+		}
+
+		// Ensure the given path exists.
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			http.Error(w, fmt.Sprintf("path %s not found on host system", path), http.StatusInternalServerError)
+			return
+		}
+
+		http.FileServer(http.Dir(path)).ServeHTTP(w, r)
+	}
+}
+
+// Options for file server rules
+
+type FileServerOptions struct {
+	EmbeddedFS fs.FS  // Instead of using Path, pass in an fs.FS. Useful for embedding the Habitat frontend.
+	BasePath   string // If set, all file server rules will be relative to this path
+}
+
+type Option func(*FileServerOptions)
+
+func WithFS(fs fs.FS) Option {
+	return func(opts *FileServerOptions) {
+		opts.EmbeddedFS = fs
+	}
+}
+
+func WithBasePath(basePath string) Option {
+	return func(opts *FileServerOptions) {
+		opts.BasePath = basePath
+	}
+}

--- a/internal/node/reverse_proxy/handler_test.go
+++ b/internal/node/reverse_proxy/handler_test.go
@@ -1,0 +1,24 @@
+package reverse_proxy
+
+import (
+	"testing"
+
+	"github.com/eagraf/habitat-new/core/state/node"
+	"github.com/eagraf/habitat-new/internal/node/config"
+)
+
+func TestGetHandlerFromRule(t *testing.T) {
+
+	fakeConfig, err := config.NewNodeConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	redirectRule := &node.ReverseProxyRule{
+		ID:     "redirect1",
+		Type:   node.ProxyRuleRedirect,
+		Target: "http://fake-target/api",
+	}
+
+	getHandlerFromRule(redirectRule, fakeConfig)
+}

--- a/internal/node/reverse_proxy/handler_test.go
+++ b/internal/node/reverse_proxy/handler_test.go
@@ -1,10 +1,12 @@
 package reverse_proxy
 
 import (
+	"net/http/httputil"
 	"testing"
 
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/config"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHandlerFromRule(t *testing.T) {
@@ -20,5 +22,10 @@ func TestGetHandlerFromRule(t *testing.T) {
 		Target: "http://fake-target/api",
 	}
 
-	getHandlerFromRule(redirectRule, fakeConfig)
+	handler, err := getHandlerFromRule(redirectRule, fakeConfig)
+	require.Nil(t, err)
+
+	if _, ok := handler.(*httputil.ReverseProxy); !ok {
+		t.Errorf("expected handler to be a *httputil.ReverseProxy, got %T", handler)
+	}
 }

--- a/internal/node/reverse_proxy/handler_test.go
+++ b/internal/node/reverse_proxy/handler_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/config"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetHandlerFromRule(t *testing.T) {
+	v := viper.New()
 
-	fakeConfig, err := config.NewNodeConfig()
+	fakeConfig, err := config.NewNodeConfigFromViper(v)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/node/reverse_proxy/proxy.go
+++ b/internal/node/reverse_proxy/proxy.go
@@ -88,7 +88,14 @@ func (r *FileServerRule) Type() string {
 func (r *FileServerRule) Match(url *url.URL) bool {
 	// TODO make this work with actual glob strings
 	// For now, just match based off of base path
-	return strings.HasPrefix(url.Path, r.Matcher)
+	if strings.HasPrefix(url.Path, r.Matcher) {
+		prefixRemoved := strings.TrimPrefix(url.Path, r.Matcher)
+		if prefixRemoved == "" {
+			return true
+		}
+		return strings.HasPrefix(prefixRemoved, "/")
+	}
+	return false
 }
 
 func (r *FileServerRule) Handler() http.Handler {
@@ -148,7 +155,14 @@ func (r *RedirectRule) Type() string {
 func (r *RedirectRule) Match(url *url.URL) bool {
 	// TODO make this work with actual glob strings
 	// For now, just match based off of base path
-	return strings.HasPrefix(url.Path, r.Matcher)
+	if strings.HasPrefix(url.Path, r.Matcher) {
+		prefixRemoved := strings.TrimPrefix(url.Path, r.Matcher)
+		if prefixRemoved == "" {
+			return true
+		}
+		return strings.HasPrefix(prefixRemoved, "/")
+	}
+	return false
 }
 
 func (r *RedirectRule) Handler() http.Handler {

--- a/internal/node/reverse_proxy/proxy.go
+++ b/internal/node/reverse_proxy/proxy.go
@@ -2,59 +2,28 @@ package reverse_proxy
 
 import (
 	"fmt"
-	"io/fs"
-	"net"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"path"
-	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/eagraf/habitat-new/core/state/node"
-	"github.com/rs/zerolog/log"
 )
 
 type RuleSet struct {
-	rules        map[string]RuleHandler
+	rules        map[string]*node.ReverseProxyRule
 	baseFilePath string // Optional, if set, all file server rules will be relative to this path
-}
-
-func (rs RuleSet) Add(name string, rule RuleHandler) error {
-	if _, ok := rs.rules[name]; ok {
-		return fmt.Errorf("rule name %s is already taken", name)
-	}
-	rs.rules[name] = rule
-	return nil
 }
 
 // AddRule is a wrapper around Add for finding the correct rule handler type.
 func (rs RuleSet) AddRule(rule *node.ReverseProxyRule) error {
-	if rule.Type == ProxyRuleRedirect {
-		url, err := url.Parse(rule.Target)
-		if err != nil {
-			return err
-		}
-		err = rs.Add(rule.ID, &RedirectRule{
-			Matcher:         rule.Matcher,
-			ForwardLocation: url,
-		})
-		if err != nil {
-			return err
-		}
-	} else if rule.Type == ProxyRuleFileServer {
-		err := rs.Add(rule.ID, &FileServerRule{
-			Matcher:  rule.Matcher,
-			Path:     rule.Target,
-			BasePath: rs.baseFilePath,
-		})
-		if err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("unknown rule type %s", rule.Type)
+	if _, ok := rs.rules[rule.ID]; ok {
+		return fmt.Errorf("reverse proxy rule with id %s is already present", rule.ID)
 	}
+
+	// Make sure the rule type is valid.
+	if rule.Type != node.ProxyRuleRedirect && rule.Type != node.ProxyRuleFileServer && rule.Type != node.ProxyRuleEmbeddedFrontend {
+		return fmt.Errorf("rule type %s is not supported", rule.Type)
+	}
+
+	// TODO we might need to make this threadsafe.
+	rs.rules[rule.ID] = rule
 	return nil
 }
 
@@ -64,133 +33,4 @@ func (rs RuleSet) Remove(name string) error {
 	}
 	delete(rs.rules, name)
 	return nil
-}
-
-type RuleHandler interface {
-	Type() string
-	Match(url *url.URL) bool
-	Handler() http.Handler
-	Rank() int
-}
-
-type FileServerRule struct {
-	Matcher string
-	Path    string
-
-	FS       fs.FS  // Optional, instead of using Path, pass in an fs.FS. Useful for embedding the Habitat frontend.
-	BasePath string // Optional, if set, all file server rules will be relative to this path
-}
-
-func (r *FileServerRule) Type() string {
-	return ProxyRuleFileServer
-}
-
-func (r *FileServerRule) Match(url *url.URL) bool {
-	// TODO make this work with actual glob strings
-	// For now, just match based off of base path
-	if strings.HasPrefix(url.Path, r.Matcher) {
-		prefixRemoved := strings.TrimPrefix(url.Path, r.Matcher)
-		if prefixRemoved == "" {
-			return true
-		}
-		return strings.HasPrefix(prefixRemoved, "/")
-	}
-	return false
-}
-
-func (r *FileServerRule) Handler() http.Handler {
-	return &FileServerHandler{
-		Prefix:   r.Matcher,
-		Path:     r.Path,
-		FS:       r.FS,
-		BasePath: r.BasePath,
-	}
-}
-
-func (r *FileServerRule) Rank() int {
-	return strings.Count(r.Matcher, "/")
-}
-
-type FileServerHandler struct {
-	Prefix string
-	Path   string
-
-	BasePath string // Optional, if set, all file server rules will be relative to this path
-	FS       fs.FS  // Optional, instead of using Path, pass in an fs.FS. Useful for embedding the Habitat frontend.
-}
-
-func (h *FileServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Try to remove prefix
-	oldPath := r.URL.Path
-	r.URL.Path = strings.TrimPrefix(oldPath, h.Prefix)
-
-	if oldPath == r.URL.Path {
-		// Something weird happened
-		_, _ = w.Write([]byte("unable to remove url path prefix"))
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
-	if h.FS != nil {
-		http.FileServer(http.FS(h.FS)).ServeHTTP(w, r)
-	} else {
-		path := h.Path
-
-		// If a base path is set, and the path is relative, use that instead
-		if h.BasePath != "" && !filepath.IsAbs(h.Path) {
-			path = filepath.Join(h.BasePath, h.Path)
-		}
-		http.FileServer(http.Dir(path)).ServeHTTP(w, r)
-	}
-}
-
-type RedirectRule struct {
-	Matcher         string
-	ForwardLocation *url.URL
-}
-
-func (r *RedirectRule) Type() string {
-	return ProxyRuleRedirect
-}
-
-func (r *RedirectRule) Match(url *url.URL) bool {
-	// TODO make this work with actual glob strings
-	// For now, just match based off of base path
-	if strings.HasPrefix(url.Path, r.Matcher) {
-		prefixRemoved := strings.TrimPrefix(url.Path, r.Matcher)
-		if prefixRemoved == "" {
-			return true
-		}
-		return strings.HasPrefix(prefixRemoved, "/")
-	}
-	return false
-}
-
-func (r *RedirectRule) Handler() http.Handler {
-	target := r.ForwardLocation.Host
-
-	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = r.ForwardLocation.Scheme
-			req.URL.Host = target
-			// TODO implement globs
-			req.URL.Path = path.Join(r.ForwardLocation.Path, strings.TrimPrefix(req.URL.Path, r.Matcher))
-		},
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout: 10 * time.Second,
-			}).Dial,
-		},
-		ModifyResponse: func(res *http.Response) error {
-			return nil
-		},
-		ErrorHandler: func(rw http.ResponseWriter, r *http.Request, err error) {
-			log.Error().Err(err).Msg("reverse proxy request forwarding error")
-			_, _ = rw.Write([]byte(err.Error()))
-			rw.WriteHeader(http.StatusInternalServerError)
-		},
-	}
-}
-
-func (r *RedirectRule) Rank() int {
-	return strings.Count(r.Matcher, "/")
 }

--- a/internal/node/reverse_proxy/proxy_test.go
+++ b/internal/node/reverse_proxy/proxy_test.go
@@ -46,22 +46,28 @@ func TestProxy(t *testing.T) {
 
 	// Create proxy server
 	proxy := NewProxyServer(logging.NewLogger(), &config.NodeConfig{})
-	err = proxy.RuleSet.Add("backend1", &RedirectRule{
-		Matcher:         "/backend1",
-		ForwardLocation: redirectedServerURL,
+	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
+		ID:      "backend1",
+		Type:    node.ProxyRuleRedirect,
+		Matcher: "/backend1",
+		Target:  redirectedServerURL.String(),
 	})
 	require.Nil(t, err)
 
 	// Test adding naming conflict
-	err = proxy.RuleSet.Add("backend1", &RedirectRule{
-		Matcher:         "/backend1",
-		ForwardLocation: redirectedServerURL,
+	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
+		ID:      "backend1",
+		Type:    node.ProxyRuleRedirect,
+		Matcher: "/backend1",
+		Target:  redirectedServerURL.String(),
 	})
 	require.NotNil(t, err)
 
-	err = proxy.RuleSet.Add("fileserver", &FileServerRule{
+	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
+		ID:      "fileserver",
+		Type:    node.ProxyRuleFileServer,
 		Matcher: "/fileserver",
-		Path:    fileDir,
+		Target:  fileDir,
 	})
 	require.Nil(t, err)
 	require.Equal(t, 2, len(proxy.RuleSet.rules))
@@ -114,25 +120,38 @@ func TestProxy(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
+	// Test the embedded frontend
+	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
+		ID:      "frontend-rule",
+		Type:    node.ProxyRuleEmbeddedFrontend,
+		Matcher: "",
+	})
+	require.Nil(t, err)
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
 	// Test removing a rule
 	err = proxy.RuleSet.Remove("fileserver")
 	require.Nil(t, err)
 	resp, err = http.Get(fmt.Sprintf("%s/fileserver/%s", url, "nonexistentfile"))
 	require.Nil(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
-	require.Equal(t, 1, len(proxy.RuleSet.rules))
+	require.Equal(t, 2, len(proxy.RuleSet.rules))
 
 	// Removing it again should fail
 	err = proxy.RuleSet.Remove("fileserver")
 	require.NotNil(t, err)
 
-	require.Equal(t, 1, len(proxy.RuleSet.rules))
+	require.Equal(t, 2, len(proxy.RuleSet.rules))
 }
 
 func TestAddRule(t *testing.T) {
 	proxy := &ProxyServer{
 		RuleSet: &RuleSet{
-			rules: make(map[string]RuleHandler),
+			rules: make(map[string]*node.ReverseProxyRule),
 		},
 	}
 
@@ -144,7 +163,7 @@ func TestAddRule(t *testing.T) {
 	})
 	require.Nil(t, err)
 	require.Equal(t, 1, len(proxy.RuleSet.rules))
-	require.Equal(t, ProxyRuleRedirect, proxy.RuleSet.rules["backend1"].Type())
+	require.Equal(t, node.ProxyRuleRedirect, proxy.RuleSet.rules["backend1"].Type)
 
 	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
 		ID:      "backend2",
@@ -154,7 +173,7 @@ func TestAddRule(t *testing.T) {
 	})
 	require.Nil(t, err)
 	require.Equal(t, 2, len(proxy.RuleSet.rules))
-	require.Equal(t, ProxyRuleFileServer, proxy.RuleSet.rules["backend2"].Type())
+	require.Equal(t, node.ProxyRuleFileServer, proxy.RuleSet.rules["backend2"].Type)
 
 	// Test unknown rule
 	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{

--- a/internal/node/reverse_proxy/proxy_test.go
+++ b/internal/node/reverse_proxy/proxy_test.go
@@ -45,7 +45,9 @@ func TestProxy(t *testing.T) {
 	file.Close()
 
 	// Create proxy server
-	proxy := NewProxyServer(logging.NewLogger(), &config.NodeConfig{})
+	config, err := config.NewTestNodeConfig(nil)
+	require.Nil(t, err)
+	proxy := NewProxyServer(logging.NewLogger(), config)
 	err = proxy.RuleSet.AddRule(&node.ReverseProxyRule{
 		ID:      "backend1",
 		Type:    node.ProxyRuleRedirect,

--- a/internal/node/reverse_proxy/restore.go
+++ b/internal/node/reverse_proxy/restore.go
@@ -12,19 +12,17 @@ type ReverseProxyRestorer struct {
 
 func (r *ReverseProxyRestorer) Restore(restoreEvent hdb.StateUpdate) error {
 	nodeState := restoreEvent.NewState().(*node.State)
-	for _, process := range nodeState.Processes {
-		rules, err := nodeState.GetReverseProxyRulesForProcess(process.ID)
-		if err != nil {
-			return err
-		}
+	if nodeState.ReverseProxyRules == nil {
+		return nil
+	}
 
-		for _, rule := range rules {
-			log.Info().Msgf("Restoring rule %s", rule)
-			err = r.ruleSet.AddRule(rule)
-			if err != nil {
-				log.Error().Msgf("error restoring rule: %s", err)
-			}
+	for _, rule := range *nodeState.ReverseProxyRules {
+		log.Info().Msgf("Restoring rule %s, matcher: %s", rule.ID, rule.Matcher)
+		err := r.ruleSet.AddRule(rule)
+		if err != nil {
+			log.Error().Msgf("error restoring rule: %s", err)
 		}
 	}
+
 	return nil
 }

--- a/internal/node/reverse_proxy/restore_test.go
+++ b/internal/node/reverse_proxy/restore_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestProcessRestorer(t *testing.T) {
 	ruleSet := &RuleSet{
-		rules: make(map[string]RuleHandler),
+		rules: make(map[string]*node.ReverseProxyRule),
 	}
 
 	restorer := &ReverseProxyRestorer{
@@ -72,5 +72,5 @@ func TestProcessRestorer(t *testing.T) {
 	err = restorer.Restore(restoreUpdate)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1, len(restorer.ruleSet.rules))
+	assert.Equal(t, 2, len(restorer.ruleSet.rules))
 }

--- a/internal/node/reverse_proxy/rules.go
+++ b/internal/node/reverse_proxy/rules.go
@@ -1,8 +1,3 @@
 package reverse_proxy
 
 type ProxyRuleType string
-
-const (
-	ProxyRuleFileServer = "file"
-	ProxyRuleRedirect   = "redirect"
-)

--- a/internal/node/reverse_proxy/server.go
+++ b/internal/node/reverse_proxy/server.go
@@ -1,31 +1,19 @@
 package reverse_proxy
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/config"
-	"github.com/eagraf/habitat-new/internal/node/hdb"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"tailscale.com/tsnet"
 )
-
-func NewProcessProxyRuleStateUpdateSubscriber(ruleSet *RuleSet) (*hdb.IdempotentStateUpdateSubscriber, error) {
-	return hdb.NewIdempotentStateUpdateSubscriber(
-		"ProcessProxyRulesSubscriber",
-		node.SchemaName,
-		[]hdb.IdempotentStateUpdateExecutor{
-			&ProcessProxyRulesExecutor{
-				RuleSet: ruleSet,
-			},
-		},
-		&ReverseProxyRestorer{
-			ruleSet: ruleSet,
-		},
-	)
-}
 
 type ProxyServer struct {
 	logger     *zerolog.Logger
@@ -37,7 +25,7 @@ func NewProxyServer(logger *zerolog.Logger, config *config.NodeConfig) *ProxySer
 	return &ProxyServer{
 		logger: logger,
 		RuleSet: &RuleSet{
-			rules:        make(map[string]RuleHandler),
+			rules:        make(map[string]*node.ReverseProxyRule),
 			baseFilePath: config.WebBundlePath(),
 		},
 		nodeConfig: config,
@@ -45,25 +33,41 @@ func NewProxyServer(logger *zerolog.Logger, config *config.NodeConfig) *ProxySer
 }
 
 func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var bestMatch RuleHandler = nil
+	var bestMatch *node.ReverseProxyRule = nil
 	// Find the matching rule with the highest "rank", aka the most slashes '/' in the URL path.
 	highestRank := -1
 	for _, rule := range s.RuleSet.rules {
-		if rule.Match(r.URL) {
-			if rule.Rank() > highestRank {
-				bestMatch = rule
-				highestRank = rule.Rank()
+		if rule != nil {
+			if matchRule(r.URL, rule) {
+				rank := rankMatch(r.URL, rule)
+				if rank > highestRank {
+					bestMatch = rule
+					highestRank = rank
+				}
 			}
 		}
 	}
 
-	// Serve the handler with the best matching rule.
-	if bestMatch != nil {
-		bestMatch.Handler().ServeHTTP(w, r)
+	// No rules matched
+	if bestMatch == nil {
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	// No rules matched
-	w.WriteHeader(http.StatusNotFound)
+
+	// Get the handler for the best matching rule
+	handler, err := getHandlerFromRule(bestMatch, s.nodeConfig)
+	if err != nil {
+		msg := fmt.Sprintf("error getting handler: %s", err)
+		log.Error().Msg(msg)
+
+		w.Write([]byte(msg))
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	// Serve the rule handler.
+	handler.ServeHTTP(w, r)
 }
 
 func (s *ProxyServer) Listener(addr string) (net.Listener, error) {
@@ -100,4 +104,24 @@ func (s *ProxyServer) Listener(addr string) (net.Listener, error) {
 	}
 
 	return listener, nil
+}
+
+// Determine whether a rule matches a URL
+func matchRule(requestURL *url.URL, rule *node.ReverseProxyRule) bool {
+	// TODO make this work with actual glob strings
+	// For now, just match based off of base path
+	if strings.HasPrefix(requestURL.Path, rule.Matcher) {
+		prefixRemoved := strings.TrimPrefix(requestURL.Path, rule.Matcher)
+		if prefixRemoved == "" {
+			return true
+		}
+		return strings.HasPrefix(prefixRemoved, "/")
+	}
+	return false
+
+}
+
+// Find the rank of a match, given a requestURL and a rule
+func rankMatch(requestURL *url.URL, rule *node.ReverseProxyRule) int {
+	return strings.Count(rule.Matcher, "/")
 }

--- a/internal/node/reverse_proxy/server.go
+++ b/internal/node/reverse_proxy/server.go
@@ -60,7 +60,10 @@ func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		msg := fmt.Sprintf("error getting handler: %s", err)
 		log.Error().Msg(msg)
 
-		w.Write([]byte(msg))
+		_, err := w.Write([]byte(msg))
+		if err != nil {
+			log.Error().Err(err).Msg("error writing error message to response")
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 
 		return

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -8,6 +8,25 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func NewProcessProxyRuleStateUpdateSubscriber(ruleSet *RuleSet) (*hdb.IdempotentStateUpdateSubscriber, error) {
+	return hdb.NewIdempotentStateUpdateSubscriber(
+		"ProcessProxyRulesSubscriber",
+		node.SchemaName,
+		[]hdb.IdempotentStateUpdateExecutor{
+			&ProcessProxyRulesExecutor{
+				RuleSet: ruleSet,
+			},
+			&AddProxyRulesExecutor{
+				RuleSet: ruleSet,
+			},
+		},
+		&ReverseProxyRestorer{
+			ruleSet: ruleSet,
+		},
+	)
+}
+
+// ProcesProxyRulesExecutor enables relevant reverse proxy rules when a process is started
 type ProcessProxyRulesExecutor struct {
 	RuleSet *RuleSet
 }
@@ -45,5 +64,38 @@ func (e *ProcessProxyRulesExecutor) Execute(update hdb.StateUpdate) error {
 // TODO remove rule when process is stopped
 
 func (e *ProcessProxyRulesExecutor) PostHook(update hdb.StateUpdate) error {
+	return nil
+}
+
+type AddProxyRulesExecutor struct {
+	RuleSet *RuleSet
+}
+
+func (e *AddProxyRulesExecutor) TransitionType() string {
+	return node.TransitionAddReverseProxyRule
+}
+
+func (e *AddProxyRulesExecutor) ShouldExecute(update hdb.StateUpdate) (bool, error) {
+	// This process is lightweight, so we can execute it every time
+	return true, nil
+}
+
+func (e *AddProxyRulesExecutor) Execute(update hdb.StateUpdate) error {
+	var addRuleTransition node.AddReverseProxyRuleTransition
+	err := json.Unmarshal(update.Transition(), &addRuleTransition)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Msgf("Adding new reverse proxy rule: %v", addRuleTransition.Rule)
+	err = e.RuleSet.AddRule(addRuleTransition.Rule)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *AddProxyRulesExecutor) PostHook(update hdb.StateUpdate) error {
 	return nil
 }

--- a/internal/node/reverse_proxy/subscriber.go
+++ b/internal/node/reverse_proxy/subscriber.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewProcessProxyRuleStateUpdateSubscriber(ruleSet *RuleSet) (*hdb.IdempotentStateUpdateSubscriber, error) {
+func NewProcessProxyRuleSubscriber(ruleSet *RuleSet) (*hdb.IdempotentStateUpdateSubscriber, error) {
 	return hdb.NewIdempotentStateUpdateSubscriber(
 		"ProcessProxyRulesSubscriber",
 		node.SchemaName,

--- a/internal/node/reverse_proxy/subscriber_test.go
+++ b/internal/node/reverse_proxy/subscriber_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/core/state/node/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSubscriber(t *testing.T) {
+func TestStartProcessExecutor(t *testing.T) {
 	executor := &ProcessProxyRulesExecutor{
 		RuleSet: &RuleSet{
-			rules: make(map[string]RuleHandler),
+			rules: make(map[string]*node.ReverseProxyRule),
 		},
 	}
 
@@ -62,7 +63,7 @@ func TestSubscriber(t *testing.T) {
 func TestBrokenRule(t *testing.T) {
 	executor := &ProcessProxyRulesExecutor{
 		RuleSet: &RuleSet{
-			rules: make(map[string]RuleHandler),
+			rules: make(map[string]*node.ReverseProxyRule),
 		},
 	}
 
@@ -96,4 +97,39 @@ func TestBrokenRule(t *testing.T) {
 	err = executor.Execute(startProcessStateUpdate)
 	assert.NotNil(t, err)
 	assert.Equal(t, 0, len(executor.RuleSet.rules))
+}
+
+func TestAddRuleExecutor(t *testing.T) {
+	subscriber, err := NewProcessProxyRuleStateUpdateSubscriber(
+		&RuleSet{
+			rules: make(map[string]*node.ReverseProxyRule),
+		},
+	)
+	require.Nil(t, err)
+
+	exec, err := subscriber.GetExecutor(node.TransitionAddReverseProxyRule)
+	require.Nil(t, err)
+	executor, _ := exec.(*AddProxyRulesExecutor)
+
+	addRuleStateUpdate, err := test_helpers.StateUpdateTestHelper(&node.AddReverseProxyRuleTransition{
+		Rule: &node.ReverseProxyRule{
+			ID:      "new-rule",
+			Type:    node.ProxyRuleRedirect,
+			Matcher: "/my-matcher",
+			Target:  "http://myhost/api",
+		},
+	}, &node.State{
+		ReverseProxyRules: &map[string]*node.ReverseProxyRule{},
+	})
+	assert.Nil(t, err)
+
+	shouldExecute, err := executor.ShouldExecute(addRuleStateUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, true, shouldExecute)
+	assert.Equal(t, 0, len(executor.RuleSet.rules))
+
+	err = executor.Execute(addRuleStateUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(executor.RuleSet.rules))
+
 }

--- a/internal/node/reverse_proxy/subscriber_test.go
+++ b/internal/node/reverse_proxy/subscriber_test.go
@@ -100,7 +100,7 @@ func TestBrokenRule(t *testing.T) {
 }
 
 func TestAddRuleExecutor(t *testing.T) {
-	subscriber, err := NewProcessProxyRuleStateUpdateSubscriber(
+	subscriber, err := NewProcessProxyRuleSubscriber(
 		&RuleSet{
 			rules: make(map[string]*node.ReverseProxyRule),
 		},


### PR DESCRIPTION
Long overdue refactor to the reverse proxy sub-system, which makes it much simpler and easier to understand:
- Get rid of the distinction between Handlers and Rules, which ended up with us having duplicate structs that basically stored the same information, which ended up being very confusing. Instead, we have a new function `getHandlerFromRule` which generates an `http.Handler` implementation based off the rule given.
- The active reverse proxy rules are derived entirely from the node's state. Previously, there were several rules such as the node API rule and frontend rule that were added to the reverse proxy, but were not shown in the app's state, which was very confusing. Now all rules are shown there and it is the source of truth.
- Create a new `AddReverseProxyRuleTransition` which does what it says.
- 