### PR TITLE
pds: small fixes

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -43,7 +43,8 @@ func main() {
 	}
 	defer dbClose()
 
-	nodeCtrl, err := controller.NewNodeController(db.Manager, nodeConfig)
+	pdsClient := controller.NewPDSClient(nodeConfig.PDSAdminUsername(), nodeConfig.PDSAdminPassword())
+	nodeCtrl, err := controller.NewNodeController(db.Manager, nodeConfig, pdsClient)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error creating node controller")
 	}
@@ -143,7 +144,7 @@ func main() {
 		// Node routes
 		api.NewVersionHandler(),
 		controller.NewGetNodeRoute(db.Manager),
-		controller.NewLoginRoute(controller.NewPDSClient(nodeConfig.PDSAdminUsername(), nodeConfig.PDSAdminUsername())),
+		controller.NewLoginRoute(pdsClient),
 		controller.NewAddUserRoute(nodeCtrl),
 		controller.NewInstallAppRoute(nodeCtrl),
 		controller.NewStartProcessHandler(nodeCtrl),

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -143,7 +143,7 @@ func main() {
 		// Node routes
 		api.NewVersionHandler(),
 		controller.NewGetNodeRoute(db.Manager),
-		controller.NewLoginRoute(&controller.PDSClient{NodeConfig: nodeConfig}),
+		controller.NewLoginRoute(controller.NewPDSClient(nodeConfig.PDSAdminUsername(), nodeConfig.PDSAdminUsername())),
 		controller.NewAddUserRoute(nodeCtrl),
 		controller.NewInstallAppRoute(nodeCtrl),
 		controller.NewStartProcessHandler(nodeCtrl),

--- a/config/air.node.toml
+++ b/config/air.node.toml
@@ -17,7 +17,7 @@ stop_on_error = true
 # When in debugging mode, it sometimes helps to have the application block immediately so that you can
 # easily debug code that executes near startup. To do this, remove the --continue flag and rebuild the docker
 # image.
-full_bin = "dlv exec --accept-multiclient --log --headless --continue --listen :4000 --api-version 2 /habitat_node"
+full_bin = "dlv exec --accept-multiclient --log --headless --listen :4000 --api-version 2 /habitat_node"
 
 # Watch these filename extensions.
 include_ext = ["go", "yml"]

--- a/core/api/pds.go
+++ b/core/api/pds.go
@@ -1,14 +1,9 @@
 package types
 
-type PDSInviteCodeResponse struct {
-	Code string `json:"code"`
-}
-
 type PDSCreateAccountRequest struct {
-	Email      string `json:"email"`
-	Handle     string `json:"handle"`
-	Password   string `json:"password"`
-	InviteCode string `json:"inviteCode"`
+	Email    string `json:"email"`
+	Handle   string `json:"handle"`
+	Password string `json:"password"`
 }
 
 type PDSCreateAccountResponse map[string]interface{}

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -46,13 +46,3 @@ export interface PDSCreateSessionRequest {
   password: string;
 }
 export type PDSCreateSessionResponse = { [key: string]: any};
-export interface PDSGetRecordRequest {
-  repo: string;
-  collection: string;
-  rkey: string;
-}
-export interface PDSGetRecordResponse {
-  uri: string;
-  cid: string;
-  value: { [key: string]: any};
-}

--- a/frontend/types/node.ts
+++ b/frontend/types/node.ts
@@ -46,26 +46,18 @@ export interface ReverseProxyRule {
   matcher: string;
   target: string;
   app_id: string;
-  fishtail_ingest_config?: FishtailIngestConfig;
-}
-export interface FishtailIngestConfig {
-  subscribed_collections: (FishtailSubscription | undefined)[];
-}
-export interface FishtailSubscription {
-  lexicon: string;
 }
 export type ReverseProxyRuleType = string;
 export const ProxyRuleFileServer: ReverseProxyRuleType = "file";
 export const ProxyRuleRedirect: ReverseProxyRuleType = "redirect";
 export const ProxyRuleEmbeddedFrontend: ReverseProxyRuleType = "embedded_frontend";
-export const ProxyRuleFishtailIngest: ReverseProxyRuleType = "fishtail_ingest";
 
 //////////
 // source: schema.go
 
 export const SchemaName = "node";
-export const CurrentVersion = "v0.0.7";
-export const LatestVersion = "v0.0.7";
+export const CurrentVersion = "v0.0.6";
+export const LatestVersion = "v0.0.6";
 export interface State {
   node_id: string;
   name: string;

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -215,15 +215,6 @@ func (c *BaseNodeController) StopProcess(processID string) error {
 }
 
 func (c *BaseNodeController) AddUser(userID, email, handle, password, certificate string) (types.PDSCreateAccountResponse, error) {
-	log.Info().Msg("AddUser")
-
-	/*
-		inviteCode, err := c.pdsClient.GetInviteCode()
-		if err != nil {
-			return nil, err
-		}
-	*/
-
 	resp, err := c.pdsClient.CreateAccount(email, handle, password)
 	if err != nil {
 		return nil, err

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -216,12 +216,12 @@ func (c *BaseNodeController) StopProcess(processID string) error {
 
 func (c *BaseNodeController) AddUser(userID, email, handle, password, certificate string) (types.PDSCreateAccountResponse, error) {
 
-	inviteCode, err := c.pdsClient.GetInviteCode(c.nodeConfig)
+	inviteCode, err := c.pdsClient.GetInviteCode()
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.pdsClient.CreateAccount(c.nodeConfig, email, handle, password, inviteCode)
+	resp, err := c.pdsClient.CreateAccount(email, handle, password, inviteCode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/controller/controller.go
+++ b/internal/node/controller/controller.go
@@ -38,11 +38,11 @@ type BaseNodeController struct {
 	pdsClient       PDSClientI
 }
 
-func NewNodeController(habitatDBManager hdb.HDBManager, config *config.NodeConfig) (*BaseNodeController, error) {
+func NewNodeController(habitatDBManager hdb.HDBManager, config *config.NodeConfig, pds PDSClientI) (*BaseNodeController, error) {
 	controller := &BaseNodeController{
 		databaseManager: habitatDBManager,
 		nodeConfig:      config,
-		pdsClient:       &PDSClient{},
+		pdsClient:       pds,
 	}
 	return controller, nil
 }
@@ -215,13 +215,16 @@ func (c *BaseNodeController) StopProcess(processID string) error {
 }
 
 func (c *BaseNodeController) AddUser(userID, email, handle, password, certificate string) (types.PDSCreateAccountResponse, error) {
+	log.Info().Msg("AddUser")
 
-	inviteCode, err := c.pdsClient.GetInviteCode()
-	if err != nil {
-		return nil, err
-	}
+	/*
+		inviteCode, err := c.pdsClient.GetInviteCode()
+		if err != nil {
+			return nil, err
+		}
+	*/
 
-	resp, err := c.pdsClient.CreateAccount(email, handle, password, inviteCode)
+	resp, err := c.pdsClient.CreateAccount(email, handle, password)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -271,9 +271,9 @@ func TestAddUser(t *testing.T) {
 
 	// Test successful add user
 
-	mockedPDSClient.EXPECT().GetInviteCode(gomock.Any()).Return("invite_code", nil).Times(1)
+	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
 
-	mockedPDSClient.EXPECT().CreateAccount(gomock.Any(), "user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
 		"did": "did_1",
 	}, nil).Times(1)
 
@@ -292,9 +292,9 @@ func TestAddUser(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test error from empty did.
-	mockedPDSClient.EXPECT().GetInviteCode(gomock.Any()).Return("invite_code", nil).Times(1)
+	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
 
-	mockedPDSClient.EXPECT().CreateAccount(gomock.Any(), "user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
 		"did": "",
 	}, nil).Times(1)
 
@@ -302,22 +302,22 @@ func TestAddUser(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Test error from missing did
-	mockedPDSClient.EXPECT().GetInviteCode(gomock.Any()).Return("invite_code", nil).Times(1)
+	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
 
-	mockedPDSClient.EXPECT().CreateAccount(gomock.Any(), "user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{}, nil).Times(1)
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{}, nil).Times(1)
 
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
 	// Test invite code error.
-	mockedPDSClient.EXPECT().GetInviteCode(gomock.Any()).Return("", errors.New("failed to create invite code")).Times(1)
+	mockedPDSClient.EXPECT().GetInviteCode().Return("", errors.New("failed to create invite code")).Times(1)
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
 	// Test create account error
-	mockedPDSClient.EXPECT().GetInviteCode(gomock.Any()).Return("invite_code", nil).Times(1)
+	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
 
-	mockedPDSClient.EXPECT().CreateAccount(gomock.Any(), "user@user.com", "username_1", "password", "invite_code").Return(nil, errors.New("failed to create account")).Times(1)
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(nil, errors.New("failed to create account")).Times(1)
 
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -301,10 +301,6 @@ func TestAddUser(t *testing.T) {
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
-	// Test invite code error.
-	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
-	assert.NotNil(t, err)
-
 	// Test create account error
 	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password").Return(nil, errors.New("failed to create account")).Times(1)
 

--- a/internal/node/controller/controller_test.go
+++ b/internal/node/controller/controller_test.go
@@ -44,8 +44,7 @@ func setupNodeDBTest(ctrl *gomock.Controller, t *testing.T) (NodeController, *mo
 	config, err := config.NewTestNodeConfig(nil)
 	require.Nil(t, err)
 
-	controller, err := NewNodeController(mockedManager, config)
-	controller.pdsClient = mockedPDSClient
+	controller, err := NewNodeController(mockedManager, config, mockedPDSClient)
 	require.Nil(t, err)
 	err = controller.InitializeNodeDB()
 	require.Nil(t, err)
@@ -271,9 +270,7 @@ func TestAddUser(t *testing.T) {
 
 	// Test successful add user
 
-	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
-
-	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password").Return(map[string]interface{}{
 		"did": "did_1",
 	}, nil).Times(1)
 
@@ -292,32 +289,24 @@ func TestAddUser(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test error from empty did.
-	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
-
-	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password").Return(map[string]interface{}{
 		"did": "",
 	}, nil).Times(1)
 
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
-	// Test error from missing did
-	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
-
-	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(map[string]interface{}{}, nil).Times(1)
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password").Return(map[string]interface{}{}, nil).Times(1)
 
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
 	// Test invite code error.
-	mockedPDSClient.EXPECT().GetInviteCode().Return("", errors.New("failed to create invite code")).Times(1)
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)
 
 	// Test create account error
-	mockedPDSClient.EXPECT().GetInviteCode().Return("invite_code", nil).Times(1)
-
-	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password", "invite_code").Return(nil, errors.New("failed to create account")).Times(1)
+	mockedPDSClient.EXPECT().CreateAccount("user@user.com", "username_1", "password").Return(nil, errors.New("failed to create account")).Times(1)
 
 	_, err = controller.AddUser("user_1", "user@user.com", "username_1", "password", "cert_1")
 	assert.NotNil(t, err)

--- a/internal/node/controller/init.go
+++ b/internal/node/controller/init.go
@@ -39,8 +39,10 @@ func generatePDSAppConfig(nodeConfig *config.NodeConfig) *types.PostAppRequest {
 						"PDS_BSKY_APP_VIEW_URL=https://api.bsky.app",
 						"PDS_BSKY_APP_VIEW_DID=did:web:api.bsky.app",
 						"PDS_REPORT_SERVICE_URL=https://mod.bsky.app",
+						"PDS_INVITE_REQUIRED=false",
 						"PDS_REPORT_SERVICE_DID=did:plc:ar7c4by46qjdydhdevvrndac",
 						"PDS_CRAWLERS=https://bsky.network",
+						"DEBUG=t",
 					},
 					"mounts": []mount.Mount{
 						{

--- a/internal/node/controller/mocks/mock_controller.go
+++ b/internal/node/controller/mocks/mock_controller.go
@@ -21,6 +21,7 @@ import (
 type MockNodeController struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeControllerMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeControllerMockRecorder is the mock recorder for MockNodeController.

--- a/internal/node/controller/mocks/mock_pds.go
+++ b/internal/node/controller/mocks/mock_pds.go
@@ -13,7 +13,6 @@ import (
 	reflect "reflect"
 
 	types "github.com/eagraf/habitat-new/core/api"
-	config "github.com/eagraf/habitat-new/internal/node/config"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -21,6 +20,7 @@ import (
 type MockPDSClientI struct {
 	ctrl     *gomock.Controller
 	recorder *MockPDSClientIMockRecorder
+	isgomock struct{}
 }
 
 // MockPDSClientIMockRecorder is the mock recorder for MockPDSClientI.
@@ -41,18 +41,18 @@ func (m *MockPDSClientI) EXPECT() *MockPDSClientIMockRecorder {
 }
 
 // CreateAccount mocks base method.
-func (m *MockPDSClientI) CreateAccount(nodeConfig *config.NodeConfig, email, handle, password, inviteCode string) (types.PDSCreateAccountResponse, error) {
+func (m *MockPDSClientI) CreateAccount(email, handle, password, inviteCode string) (types.PDSCreateAccountResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", nodeConfig, email, handle, password, inviteCode)
+	ret := m.ctrl.Call(m, "CreateAccount", email, handle, password, inviteCode)
 	ret0, _ := ret[0].(types.PDSCreateAccountResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockPDSClientIMockRecorder) CreateAccount(nodeConfig, email, handle, password, inviteCode any) *gomock.Call {
+func (mr *MockPDSClientIMockRecorder) CreateAccount(email, handle, password, inviteCode any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockPDSClientI)(nil).CreateAccount), nodeConfig, email, handle, password, inviteCode)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockPDSClientI)(nil).CreateAccount), email, handle, password, inviteCode)
 }
 
 // CreateSession mocks base method.
@@ -71,16 +71,16 @@ func (mr *MockPDSClientIMockRecorder) CreateSession(identifier, password any) *g
 }
 
 // GetInviteCode mocks base method.
-func (m *MockPDSClientI) GetInviteCode(nodeConfig *config.NodeConfig) (string, error) {
+func (m *MockPDSClientI) GetInviteCode() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInviteCode", nodeConfig)
+	ret := m.ctrl.Call(m, "GetInviteCode")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetInviteCode indicates an expected call of GetInviteCode.
-func (mr *MockPDSClientIMockRecorder) GetInviteCode(nodeConfig any) *gomock.Call {
+func (mr *MockPDSClientIMockRecorder) GetInviteCode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInviteCode", reflect.TypeOf((*MockPDSClientI)(nil).GetInviteCode), nodeConfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInviteCode", reflect.TypeOf((*MockPDSClientI)(nil).GetInviteCode))
 }

--- a/internal/node/controller/mocks/mock_pds.go
+++ b/internal/node/controller/mocks/mock_pds.go
@@ -41,18 +41,18 @@ func (m *MockPDSClientI) EXPECT() *MockPDSClientIMockRecorder {
 }
 
 // CreateAccount mocks base method.
-func (m *MockPDSClientI) CreateAccount(email, handle, password, inviteCode string) (types.PDSCreateAccountResponse, error) {
+func (m *MockPDSClientI) CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", email, handle, password, inviteCode)
+	ret := m.ctrl.Call(m, "CreateAccount", email, handle, password)
 	ret0, _ := ret[0].(types.PDSCreateAccountResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockPDSClientIMockRecorder) CreateAccount(email, handle, password, inviteCode any) *gomock.Call {
+func (mr *MockPDSClientIMockRecorder) CreateAccount(email, handle, password any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockPDSClientI)(nil).CreateAccount), email, handle, password, inviteCode)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockPDSClientI)(nil).CreateAccount), email, handle, password)
 }
 
 // CreateSession mocks base method.
@@ -68,19 +68,4 @@ func (m *MockPDSClientI) CreateSession(identifier, password string) (types.PDSCr
 func (mr *MockPDSClientIMockRecorder) CreateSession(identifier, password any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockPDSClientI)(nil).CreateSession), identifier, password)
-}
-
-// GetInviteCode mocks base method.
-func (m *MockPDSClientI) GetInviteCode() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInviteCode")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetInviteCode indicates an expected call of GetInviteCode.
-func (mr *MockPDSClientIMockRecorder) GetInviteCode() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInviteCode", reflect.TypeOf((*MockPDSClientI)(nil).GetInviteCode))
 }

--- a/internal/node/controller/pds.go
+++ b/internal/node/controller/pds.go
@@ -13,8 +13,7 @@ import (
 
 type PDSClientI interface {
 	CreateSession(identifier, password string) (types.PDSCreateSessionResponse, error)
-	GetInviteCode() (string, error)
-	CreateAccount(email, handle, password, inviteCode string) (types.PDSCreateAccountResponse, error)
+	CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error)
 }
 
 type PDSClient struct {
@@ -26,28 +25,11 @@ func NewPDSClient(username string, password string) *PDSClient {
 	return &PDSClient{username, password}
 }
 
-func (p *PDSClient) GetInviteCode() (string, error) {
-	// Parse the response body to get the invite code
-	body, err := p.makePDSHttpReq("com.atproto.server.createInviteCode", http.MethodPost, []byte("{\"useCount\": 1}"), true)
-	if err != nil {
-		return "", err
-	}
-
-	var inviteResponse types.PDSInviteCodeResponse
-	err = json.Unmarshal(body, &inviteResponse)
-	if err != nil {
-		return "", err
-	}
-
-	return inviteResponse.Code, nil
-}
-
-func (p *PDSClient) CreateAccount(email, handle, password, inviteCode string) (types.PDSCreateAccountResponse, error) {
+func (p *PDSClient) CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error) {
 	reqBody := types.PDSCreateAccountRequest{
-		Email:      email,
-		Handle:     handle,
-		Password:   password,
-		InviteCode: inviteCode,
+		Email:    email,
+		Handle:   handle,
+		Password: password,
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/internal/node/controller/pds.go
+++ b/internal/node/controller/pds.go
@@ -16,16 +16,18 @@ type PDSClientI interface {
 	CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error)
 }
 
-type PDSClient struct {
+var _ PDSClientI = &pdsClient{}
+
+type pdsClient struct {
 	pdsUsername string
 	pdsPassword string
 }
 
-func NewPDSClient(username string, password string) *PDSClient {
-	return &PDSClient{username, password}
+func NewPDSClient(username string, password string) PDSClientI {
+	return &pdsClient{username, password}
 }
 
-func (p *PDSClient) CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error) {
+func (p *pdsClient) CreateAccount(email, handle, password string) (types.PDSCreateAccountResponse, error) {
 	reqBody := types.PDSCreateAccountRequest{
 		Email:    email,
 		Handle:   handle,
@@ -51,7 +53,7 @@ func (p *PDSClient) CreateAccount(email, handle, password string) (types.PDSCrea
 	return createAccountResponse, nil
 }
 
-func (p *PDSClient) CreateSession(identifier, password string) (types.PDSCreateSessionResponse, error) {
+func (p *pdsClient) CreateSession(identifier, password string) (types.PDSCreateSessionResponse, error) {
 	reqBody := types.PDSCreateSessionRequest{
 		Identifier: identifier,
 		Password:   password,
@@ -77,7 +79,7 @@ func (p *PDSClient) CreateSession(identifier, password string) (types.PDSCreateS
 }
 
 // Helper function to make HTTP requests to PDS
-func (p *PDSClient) makePDSHttpReq(endpoint, method string, body []byte, isAdminReq bool) ([]byte, error) {
+func (p *pdsClient) makePDSHttpReq(endpoint, method string, body []byte, isAdminReq bool) ([]byte, error) {
 	pdsURL := fmt.Sprintf("http://%s:%s/xrpc/%s", "host.docker.internal", "5001", endpoint)
 
 	req, err := http.NewRequest(method, pdsURL, bytes.NewReader(body))

--- a/pkg/raft/transport/http_transport_test.go
+++ b/pkg/raft/transport/http_transport_test.go
@@ -2,7 +2,6 @@ package transport
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/raft"
@@ -26,14 +25,12 @@ func TestRPCMarshaling(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Println(string(aeBuf))
 
 	res, err := unmarshalRPCRequest(rpcAppendEntries, aeBuf)
 	if err != nil {
 		t.Error(err)
 	}
 
-	fmt.Println(res)
 	assert.Equal(t, raft.ProtocolVersion(3), res.(*raft.AppendEntriesRequest).RPCHeader.ProtocolVersion)
 	assert.Equal(t, uint64(20), res.(*raft.AppendEntriesRequest).PrevLogEntry)
 	assert.Equal(t, uint64(102), res.(*raft.AppendEntriesRequest).Entries[0].Index)


### PR DESCRIPTION
- set `PDS_INVITE_REQUIRED=false` in the default PDS envs to make testing a little easier. we were just bypassing this anyways by doing it all internally. (need to clear volumes to get updated PDS container)
- PDS client shouldn't take in node config, only what it needs. right now this is just admin password.
- reuse pds client rather than creating it in two places -- make this private actually so that this is harder to mess up
- randome comment / log cleanup