### PR TITLE
simplify privi

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -199,13 +199,11 @@ func main() {
 		panic("unimplemented")
 	}
 
-	// Add privi routes
+	// Add privy routes
 	priviServer := privi.NewServer(
-		constants.DefaultPDSHostname,
+		"todo-did-fill-me-in",
 		habitatResolver,
 		&privi.NoopEncrypter{}, /* TODO: use actual encryption */
-		bffauth.NewClient(),
-		bffProvider,
 		permissions.NewDummyStore(),
 	)
 	routes = append(routes, priviServer.GetRoutes()...)

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
@@ -184,27 +185,14 @@ func main() {
 		routes = append(routes, appstore.NewAvailableAppsRoute(nodeConfig.HabitatPath()))
 	}
 
-	// TODO: eventually we need a way given a did to resolve the habitat server host.
-	// This likely can go into the DID document services
-	// For now, hardcode it. This is used by the priviServer.
-	habitatResolver := func(did string) string {
-		panic("unimplemented")
-	}
-
-	// TODO: this is a hack. the privy server should have a way to register users with a did.
-	did := ""
+	// TODO: read from persisted state about permissions.
+	perms := make(map[syntax.DID]permissions.Store)
 	for _, u := range initState.Users {
-		did = u.DID
-	}
-	if did == "" {
-		log.Fatal().Msg("no did found amongst users")
+		perms[syntax.DID(u.DID)] = permissions.NewDummyStore()
 	}
 	// Add privy routes
 	priviServer := privi.NewServer(
-		"todo-did-fill-me-in",
-		habitatResolver,
-		&privi.NoopEncrypter{}, /* TODO: use actual encryption */
-		permissions.NewDummyStore(),
+		perms,
 	)
 	routes = append(routes, priviServer.GetRoutes()...)
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/eagraf/habitat-new/core/permissions"
 	"github.com/eagraf/habitat-new/core/state/node"
-	"github.com/eagraf/habitat-new/internal/bffauth"
 	"github.com/eagraf/habitat-new/internal/docker"
 	"github.com/eagraf/habitat-new/internal/node/api"
 	"github.com/eagraf/habitat-new/internal/node/appstore"
@@ -185,13 +184,6 @@ func main() {
 		routes = append(routes, appstore.NewAvailableAppsRoute(nodeConfig.HabitatPath()))
 	}
 
-	// Add BFF auth routes
-	bffProvider := bffauth.NewProvider(
-		bffauth.NewInMemorySessionPersister(),
-		[]byte("temp_signing_key"), // TODO @eagraf - use a real signing key
-	)
-	routes = append(routes, bffProvider.GetRoutes()...)
-
 	// TODO: eventually we need a way given a did to resolve the habitat server host.
 	// This likely can go into the DID document services
 	// For now, hardcode it. This is used by the priviServer.
@@ -199,6 +191,14 @@ func main() {
 		panic("unimplemented")
 	}
 
+	// TODO: this is a hack. the privy server should have a way to register users with a did.
+	did := ""
+	for _, u := range initState.Users {
+		did = u.DID
+	}
+	if did == "" {
+		log.Fatal().Msg("no did found amongst users")
+	}
 	// Add privy routes
 	priviServer := privi.NewServer(
 		"todo-did-fill-me-in",

--- a/internal/privi/server.go
+++ b/internal/privi/server.go
@@ -41,7 +41,10 @@ func NewServer(didToStores map[syntax.DID]permissions.Store) *Server {
 		dir:    identity.DefaultDirectory(),
 	}
 	for did, perms := range didToStores {
-		server.Register(did, perms)
+		err := server.Register(did, perms)
+		if err != nil {
+			log.Err(err)
+		}
 	}
 	return server
 }


### PR DESCRIPTION
We realized with `atproto-proxy` header, we can remove a bunch of code and simplify paths. clients should set `atproto-proxy` header correctly by looking up where privi is hosted for a given DID.