### PR TITLE
pds: add to docker compose 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ install:: $(DEV_HABITAT_PATH)/habitat.yml $(CERT_DIR)/dev_node_cert.pem $(CERT_D
 docker-build:
 	docker compose -f ./build/compose.yml build
 
+# There's an issue when the front end has new dependencies that the package.json and pnpm-lock.yaml are not correctly updated. So rebuild with force no cache.
+docker-build-no-cache:
+	docker compose -f ./build/compose.yml build --no-cache
+
 run-dev: $(PDS_BLOB_DIR) $(CERT_DIR)/dev_root_user_cert.pem $(CERT_DIR)/dev_node_cert.pem $(DEV_HABITAT_CONFIG_PATH) $(PERMS_DIR) $(DEV_HABITAT_ENV_PATH)
 	TOPDIR=$(TOPDIR) \
 	DOCKER_WORKDIR=$(DOCKER_WORKDIR) \

--- a/build/compose.yml
+++ b/build/compose.yml
@@ -42,5 +42,18 @@ services:
       - habitat_frontend
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  # Copied from instructions here: https://github.com/bluesky-social/pds/blob/main/compose.yaml
+  pds:
+    container_name: pds
+    image: ghcr.io/bluesky-social/pds:0.4
+    restart: unless-stopped
+    ports:
+      - "0.0.0.0:5001:3000/tcp"
+    volumes:
+      - type: bind
+        source: ${DEV_HABITAT_APP_PATH}/pds
+        target: /pds
+    env_file:
+      - pds.env
 volumes:
   node_modules:

--- a/build/pds.env
+++ b/build/pds.env
@@ -1,0 +1,9 @@
+PDS_DEV_MODE=true
+PDS_DATA_DIRECTORY=/pds
+PDS_BLOBSTORE_DISK_LOCATION=/pds/blocks
+PDS_ADMIN_PASSWORD=password
+PDS_INVITE_REQUIRED=false
+DEBUG=true
+# The following are required for PDS to start-up. Need a better way to manage these.
+PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=5290bb1866a03fb23b09a6ffd64d21f6a4ebf624eaa301930eeb81740699239c
+PDS_JWT_SECRET=bd6df801372d7058e1ce472305d7fc2e

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -104,14 +104,21 @@ func main() {
 	}
 
 	// Generate the list of apps to have installed and started when the node first comes up
-	_, pdsAppProxyRule := generatePDSAppConfig(nodeConfig)
+	// TODO: remove hard-codes by having this type of config in .yml or something similar
+	pdsProxyRule := &node.ReverseProxyRule{
+		ID:      "pds-app-reverse-proxy-rule",
+		AppID:   "pds-default-app-ID",
+		Type:    "redirect",
+		Matcher: "/xrpc",
+		Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
+	}
 	defaultApps, defaultProxyRules, err := nodeConfig.DefaultApps()
 	if err != nil {
 		log.Fatal().Err(err).Msg("unable to generate proxy rules")
 	}
 
 	apps := defaultApps
-	rules := append(append(defaultProxyRules, pdsAppProxyRule), proxyRules...)
+	rules := append(append(defaultProxyRules, pdsProxyRule), proxyRules...)
 
 	initState, initialTransitions, err := initialState(nodeConfig.RootUserCertB64(), apps, rules)
 	if err != nil {
@@ -280,77 +287,6 @@ func main() {
 	log.Info().Msg("Finished!")
 }
 
-func generatePDSAppConfig(
-	nodeConfig *config.NodeConfig,
-) (*node.AppInstallation, *node.ReverseProxyRule) {
-	// pdsMountDir := filepath.Join(nodeConfig.HabitatAppPath(), "pds")
-
-	// TODO @eagraf - unhardcode as much of this as possible
-	appID := "pds-default-app-ID"
-	return nil, &node.ReverseProxyRule{
-		ID:      "pds-app-reverse-proxy-rule",
-		AppID:   appID,
-		Type:    "redirect",
-		Matcher: "/xrpc",
-		Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
-	}
-	/*
-		return &node.AppInstallation{
-				ID:      appID,
-				Name:    "pds",
-				Version: "1",
-				UserID:  constants.RootUserID,
-				Package: &node.Package{
-					Driver: node.DriverTypeDocker,
-					DriverConfig: map[string]interface{}{
-						"env": []string{
-							fmt.Sprintf("PDS_HOSTNAME=%s", nodeConfig.Domain()),
-							"PDS_DEV_MODE=true",
-							"PDS_DATA_DIRECTORY=/pds",
-							"PDS_BLOBSTORE_DISK_LOCATION=/pds/blocks",
-							"PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=5290bb1866a03fb23b09a6ffd64d21f6a4ebf624eaa301930eeb81740699239c",
-							"PDS_JWT_SECRET=bd6df801372d7058e1ce472305d7fc2e",
-							"PDS_ADMIN_PASSWORD=password",
-							"PDS_BSKY_APP_VIEW_URL=https://api.bsky.app",
-							"PDS_BSKY_APP_VIEW_DID=did:web:api.bsky.app",
-							"PDS_REPORT_SERVICE_URL=https://mod.bsky.app",
-							"PDS_INVITE_REQUIRED=false",
-							"PDS_REPORT_SERVICE_DID=did:plc:ar7c4by46qjdydhdevvrndac",
-							"PDS_CRAWLERS=https://bsky.network",
-							"DEBUG=true",
-						},
-						"mounts": []mount.Mount{
-							{
-								Type:   "bind",
-								Source: pdsMountDir,
-								Target: "/pds",
-							},
-						},
-						"exposed_ports": []string{constants.DefaultPortPDS},
-						"port_bindings": map[nat.Port][]nat.PortBinding{
-							"3000/tcp": {
-								{
-									HostIP:   "0.0.0.0",
-									HostPort: constants.DefaultPortPDS,
-								},
-							},
-						},
-					},
-					RegistryURLBase:    "registry.hub.docker.com",
-					RegistryPackageID:  "ethangraf/pds",
-					RegistryPackageTag: "latest",
-				},
-			},
-			&node.ReverseProxyRule{
-				ID:      "pds-app-reverse-proxy-rule",
-				AppID:   appID,
-				Type:    "redirect",
-				Matcher: "/xrpc",
-				Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
-			}
-	*/
-}
-
 func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.ReverseProxyRule, error) {
 	apiURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
 	if err != nil {
@@ -433,7 +369,6 @@ func initialState(
 	state.SetRootUserCert(rootUserCert)
 
 	for _, app := range startApps {
-		fmt.Println("startApp", startApps)
 		state.AppInstallations[app.ID] = app
 		state.AppInstallations[app.ID].State = node.AppLifecycleStateInstalled
 	}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -15,9 +15,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/docker"
 	"github.com/eagraf/habitat-new/internal/node/api"
@@ -106,13 +104,13 @@ func main() {
 	}
 
 	// Generate the list of apps to have installed and started when the node first comes up
-	pdsApp, pdsAppProxyRule := generatePDSAppConfig(nodeConfig)
+	_, pdsAppProxyRule := generatePDSAppConfig(nodeConfig)
 	defaultApps, defaultProxyRules, err := nodeConfig.DefaultApps()
 	if err != nil {
 		log.Fatal().Err(err).Msg("unable to generate proxy rules")
 	}
 
-	apps := append(defaultApps, pdsApp)
+	apps := defaultApps
 	rules := append(append(defaultProxyRules, pdsAppProxyRule), proxyRules...)
 
 	initState, initialTransitions, err := initialState(nodeConfig.RootUserCertB64(), apps, rules)
@@ -285,63 +283,72 @@ func main() {
 func generatePDSAppConfig(
 	nodeConfig *config.NodeConfig,
 ) (*node.AppInstallation, *node.ReverseProxyRule) {
-	pdsMountDir := filepath.Join(nodeConfig.HabitatAppPath(), "pds")
+	// pdsMountDir := filepath.Join(nodeConfig.HabitatAppPath(), "pds")
 
 	// TODO @eagraf - unhardcode as much of this as possible
 	appID := "pds-default-app-ID"
-	return &node.AppInstallation{
-			ID:      appID,
-			Name:    "pds",
-			Version: "1",
-			UserID:  constants.RootUserID,
-			Package: &node.Package{
-				Driver: node.DriverTypeDocker,
-				DriverConfig: map[string]interface{}{
-					"env": []string{
-						fmt.Sprintf("PDS_HOSTNAME=%s", nodeConfig.Domain()),
-						"PDS_DEV_MODE=true",
-						"PDS_DATA_DIRECTORY=/pds",
-						"PDS_BLOBSTORE_DISK_LOCATION=/pds/blocks",
-						"PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=5290bb1866a03fb23b09a6ffd64d21f6a4ebf624eaa301930eeb81740699239c",
-						"PDS_JWT_SECRET=bd6df801372d7058e1ce472305d7fc2e",
-						"PDS_ADMIN_PASSWORD=password",
-						"PDS_BSKY_APP_VIEW_URL=https://api.bsky.app",
-						"PDS_BSKY_APP_VIEW_DID=did:web:api.bsky.app",
-						"PDS_REPORT_SERVICE_URL=https://mod.bsky.app",
-						"PDS_INVITE_REQUIRED=false",
-						"PDS_REPORT_SERVICE_DID=did:plc:ar7c4by46qjdydhdevvrndac",
-						"PDS_CRAWLERS=https://bsky.network",
-						"DEBUG=true",
-					},
-					"mounts": []mount.Mount{
-						{
-							Type:   "bind",
-							Source: pdsMountDir,
-							Target: "/pds",
+	return nil, &node.ReverseProxyRule{
+		ID:      "pds-app-reverse-proxy-rule",
+		AppID:   appID,
+		Type:    "redirect",
+		Matcher: "/xrpc",
+		Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
+	}
+	/*
+		return &node.AppInstallation{
+				ID:      appID,
+				Name:    "pds",
+				Version: "1",
+				UserID:  constants.RootUserID,
+				Package: &node.Package{
+					Driver: node.DriverTypeDocker,
+					DriverConfig: map[string]interface{}{
+						"env": []string{
+							fmt.Sprintf("PDS_HOSTNAME=%s", nodeConfig.Domain()),
+							"PDS_DEV_MODE=true",
+							"PDS_DATA_DIRECTORY=/pds",
+							"PDS_BLOBSTORE_DISK_LOCATION=/pds/blocks",
+							"PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=5290bb1866a03fb23b09a6ffd64d21f6a4ebf624eaa301930eeb81740699239c",
+							"PDS_JWT_SECRET=bd6df801372d7058e1ce472305d7fc2e",
+							"PDS_ADMIN_PASSWORD=password",
+							"PDS_BSKY_APP_VIEW_URL=https://api.bsky.app",
+							"PDS_BSKY_APP_VIEW_DID=did:web:api.bsky.app",
+							"PDS_REPORT_SERVICE_URL=https://mod.bsky.app",
+							"PDS_INVITE_REQUIRED=false",
+							"PDS_REPORT_SERVICE_DID=did:plc:ar7c4by46qjdydhdevvrndac",
+							"PDS_CRAWLERS=https://bsky.network",
+							"DEBUG=true",
 						},
-					},
-					"exposed_ports": []string{constants.DefaultPortPDS},
-					"port_bindings": map[nat.Port][]nat.PortBinding{
-						"3000/tcp": {
+						"mounts": []mount.Mount{
 							{
-								HostIP:   "0.0.0.0",
-								HostPort: constants.DefaultPortPDS,
+								Type:   "bind",
+								Source: pdsMountDir,
+								Target: "/pds",
+							},
+						},
+						"exposed_ports": []string{constants.DefaultPortPDS},
+						"port_bindings": map[nat.Port][]nat.PortBinding{
+							"3000/tcp": {
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: constants.DefaultPortPDS,
+								},
 							},
 						},
 					},
+					RegistryURLBase:    "registry.hub.docker.com",
+					RegistryPackageID:  "ethangraf/pds",
+					RegistryPackageTag: "latest",
 				},
-				RegistryURLBase:    "registry.hub.docker.com",
-				RegistryPackageID:  "ethangraf/pds",
-				RegistryPackageTag: "latest",
 			},
-		},
-		&node.ReverseProxyRule{
-			ID:      "pds-app-reverse-proxy-rule",
-			AppID:   appID,
-			Type:    "redirect",
-			Matcher: "/xrpc",
-			Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
-		}
+			&node.ReverseProxyRule{
+				ID:      "pds-app-reverse-proxy-rule",
+				AppID:   appID,
+				Type:    "redirect",
+				Matcher: "/xrpc",
+				Target:  fmt.Sprintf("https://%s/xrpc", constants.DefaultPDSHostname),
+			}
+	*/
 }
 
 func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.ReverseProxyRule, error) {
@@ -426,6 +433,7 @@ func initialState(
 	state.SetRootUserCert(rootUserCert)
 
 	for _, app := range startApps {
+		fmt.Println("startApp", startApps)
 		state.AppInstallations[app.ID] = app
 		state.AppInstallations[app.ID].State = node.AppLifecycleStateInstalled
 	}

--- a/internal/node/reverse_proxy/server.go
+++ b/internal/node/reverse_proxy/server.go
@@ -68,7 +68,7 @@ func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("------> Serving request for ", r.URL, " to ", bestMatch.Target)
+	// fmt.Println("------> Serving request for ", r.URL, " to ", bestMatch.Target)
 	// Serve the rule handler.
 	handler.ServeHTTP(w, r)
 }

--- a/internal/permissions/permission_store_test.go
+++ b/internal/permissions/permission_store_test.go
@@ -109,10 +109,10 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 
 	exp := map[string][]string{
-		"app.bsky":             []string{"did:2"},
-		"app.bsky.likes":       []string{"did:1"},
-		"app.bsky.posts":       []string{"did:2"},
-		"app.bsky.posts.post1": []string{},
+		"app.bsky":             {"did:2"},
+		"app.bsky.likes":       {"did:1"},
+		"app.bsky.posts":       {"did:2"},
+		"app.bsky.posts.post1": {},
 	}
 
 	for lex, perm := range perms {


### PR DESCRIPTION
Let's use the official pds and always run it in our docker compose since habitat is being packaged together with it anyways. A couple of things:
- This pds will be coupled to the permissions. So it is essentially a private data server.