### PR TITLE
Allow for proxy rules to be configured at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ next
 frontend/.next/
 frontend/next-env.d.ts
 frontend/out/
+
+# Ignore custom node config
+config/habitat.dev.yml
+

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -377,7 +377,12 @@ func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.Revers
 		frontendRule.Type = node.ProxyRuleEmbeddedFrontend
 	}
 
-	return []*node.ReverseProxyRule{
+	apiURL, err = url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
+	if err != nil {
+		return nil, err
+	}
+
+	res := []*node.ReverseProxyRule{
 		{
 			ID:      "default-rule-api",
 			Type:    node.ProxyRuleRedirect,
@@ -422,7 +427,19 @@ func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.Revers
 			Target:  config.HabitatPath() + "/well-known",
 		},
 		frontendRule,
-	}, nil
+	}
+
+	// Add any additional reverse proxy rules from the config file
+	configRules, err := config.ReverseProxyRules()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range configRules {
+		res = append(res, rule)
+	}
+
+	return res, nil
 }
 
 func initialState(

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -356,11 +356,6 @@ func generatePDSAppConfig(
 }
 
 func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.ReverseProxyRule, error) {
-	apiURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
-	if err != nil {
-		return nil, err
-	}
-
 	frontendRule := &node.ReverseProxyRule{
 		ID:      "default-rule-frontend",
 		Matcher: "", // Root matcher
@@ -377,7 +372,7 @@ func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.Revers
 		frontendRule.Type = node.ProxyRuleEmbeddedFrontend
 	}
 
-	apiURL, err = url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
+	apiURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", constants.DefaultPortHabitatAPI))
 	if err != nil {
 		return nil, err
 	}
@@ -435,9 +430,7 @@ func generateDefaultReverseProxyRules(config *config.NodeConfig) ([]*node.Revers
 		return nil, err
 	}
 
-	for _, rule := range configRules {
-		res = append(res, rule)
-	}
+	res = append(res, configRules...)
 
 	return res, nil
 }

--- a/core/state/node/app_installation.go
+++ b/core/state/node/app_installation.go
@@ -23,6 +23,13 @@ type AppInstallation struct {
 	*Package `yaml:",inline"`
 }
 
+// InstallAppRequest represents a request to install an application
+type InstallAppRequest struct {
+	AppInstallation   *AppInstallation    `json:"app_installation" yaml:"app_installation"`
+	ReverseProxyRules []*ReverseProxyRule `json:"reverse_proxy_rules" yaml:"reverse_proxy_rules"`
+	StartAfterInstall bool
+}
+
 // AppInstallationConfig is a struct to hold the configuration for a docker container
 // Most of these types are taken directly from the Docker Go SDK
 type AppInstallationConfig struct {

--- a/frontend/src/components/reverseProxyRuleList.tsx
+++ b/frontend/src/components/reverseProxyRuleList.tsx
@@ -15,7 +15,9 @@ const ReverseProxyRuleList: React.FC<ReverseProxyRuleListProps> = ({ rules }) =>
         <ul className="space-y-4">
           {Object.entries(rules).map(([key, rule]) => (
             <li key={key} className="bg-white p-4 rounded-lg shadow">
-              <div className="font-semibold">Rule: {key}</div>
+              <div className="font-semibold">
+                <a href={rule.matcher} className="text-blue-700">Rule: {key}</a>
+              </div>
               <div>Type: {rule.type}</div>
               <div>Target: {rule.target}</div>
               <div>Matcher: {rule.matcher}</div>

--- a/internal/node/appstore/routes.go
+++ b/internal/node/appstore/routes.go
@@ -9,7 +9,7 @@ import (
 
 	"text/template"
 
-	"github.com/eagraf/habitat-new/internal/node/controller"
+	"github.com/eagraf/habitat-new/core/state/node"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -21,7 +21,7 @@ import (
 var appsDevYml embed.FS
 
 // getAppsList returns the contents of the embedded apps.dev.yml file
-func getDevAppsList(path string) ([]*controller.InstallAppRequest, error) {
+func getDevAppsList(path string) ([]*node.InstallAppRequest, error) {
 	raw, err := fs.ReadFile(appsDevYml, "apps.dev.yml.tpl")
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func getDevAppsList(path string) ([]*controller.InstallAppRequest, error) {
 }
 
 // Render the template for the dev apps list. Only used in dev mode.
-func renderDevAppsList(path string, raw []byte) ([]*controller.InstallAppRequest, error) {
+func renderDevAppsList(path string, raw []byte) ([]*node.InstallAppRequest, error) {
 	tmpl, err := template.New("apps").Parse(string(raw))
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func renderDevAppsList(path string, raw []byte) ([]*controller.InstallAppRequest
 
 	yml := buf.Bytes()
 
-	var appsList []*controller.InstallAppRequest
+	var appsList []*node.InstallAppRequest
 	err = yaml.Unmarshal(yml, &appsList)
 	if err != nil {
 		return nil, err

--- a/internal/node/appstore/routes_test.go
+++ b/internal/node/appstore/routes_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/eagraf/habitat-new/internal/node/controller"
+	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,7 +77,7 @@ func TestAvailableAppsRouteDev(t *testing.T) {
 	bytes, err := io.ReadAll(resp.Result().Body)
 	require.NoError(t, err)
 
-	var respBody []*controller.InstallAppRequest
+	var respBody []*node.InstallAppRequest
 	require.NoError(t, json.Unmarshal(bytes, &respBody))
 
 	require.Equal(t, 2, len(respBody))

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/eagraf/habitat-new/core/state/node"
 	"github.com/eagraf/habitat-new/internal/node/constants"
-	"github.com/eagraf/habitat-new/internal/node/controller"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -365,7 +364,7 @@ func (n *NodeConfig) FrontendDev() bool {
 }
 
 func (n *NodeConfig) DefaultApps() ([]*node.AppInstallation, []*node.ReverseProxyRule, error) {
-	var appRequestsMap map[string]*controller.InstallAppRequest
+	var appRequestsMap map[string]*node.InstallAppRequest
 	err := n.viper.UnmarshalKey("default_apps", &appRequestsMap, viper.DecoderConfigOption(
 		func(decoderConfig *mapstructure.DecoderConfig) {
 			decoderConfig.TagName = "yaml"

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -385,6 +385,21 @@ func (n *NodeConfig) DefaultApps() ([]*node.AppInstallation, []*node.ReverseProx
 	return apps, rules, nil
 }
 
+func (n *NodeConfig) ReverseProxyRules() ([]*node.ReverseProxyRule, error) {
+	var rules []*node.ReverseProxyRule
+	err := n.viper.UnmarshalKey("reverse_proxy_rules", &rules, viper.DecoderConfigOption(
+		func(decoderConfig *mapstructure.DecoderConfig) {
+			decoderConfig.TagName = "yaml"
+			decoderConfig.Squash = true
+		},
+	))
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal default reverse proxy rules")
+		return nil, err
+	}
+	return rules, nil
+}
+
 // Helper functions
 
 func homedir() (string, error) {

--- a/internal/node/controller/installation_test.go
+++ b/internal/node/controller/installation_test.go
@@ -72,7 +72,7 @@ func TestInstallAppController(t *testing.T) {
 	middleware := &test_helpers.TestAuthMiddleware{UserID: "user_1"}
 	handler := middleware.Middleware(http.HandlerFunc(ctrlServer.InstallApp))
 	resp := httptest.NewRecorder()
-	b, err := json.Marshal(&InstallAppRequest{
+	b, err := json.Marshal(&node.InstallAppRequest{
 		AppInstallation: &node.AppInstallation{
 			Name:    "app_name1",
 			Version: "1",

--- a/internal/node/controller/server.go
+++ b/internal/node/controller/server.go
@@ -91,17 +91,11 @@ func (s *CtrlServer) ListProcesses(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type InstallAppRequest struct {
-	AppInstallation   *node.AppInstallation    `json:"app_installation" yaml:"app_installation"`
-	ReverseProxyRules []*node.ReverseProxyRule `json:"reverse_proxy_rules" yaml:"reverse_proxy_rules"`
-	StartAfterInstall bool
-}
-
 func (s *CtrlServer) InstallApp(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("user_id")
 	// TODO: authenticate user
 
-	var req InstallAppRequest
+	var req node.InstallAppRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
Allow for custom proxy rules to be passed in from config files. This makes debugging and testing new apps really easy.For example, just run a node backend on your machine, and tell habitat what node and host its running on.

