### PR TITLE
XRPC Broker

### DIFF
--- a/internal/auth/broker.go
+++ b/internal/auth/broker.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/gorilla/sessions"
+)
+
+type xrpcBrokerHandler struct {
+	htuURL       string
+	oauthClient  OAuthClient
+	sessionStore sessions.Store
+}
+
+func (h *xrpcBrokerHandler) Method() string {
+	return http.MethodPost
+}
+
+func (h *xrpcBrokerHandler) Pattern() string {
+	return "/xrpc/{rest...}"
+}
+
+func (h *xrpcBrokerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Note: this is effectively acting as a reverse proxy in front of the XRPC endpoint.
+	// Using the main Habitat reverse proxy isn't sufficient because of the additional
+	// roundtrips DPoP requires.
+	dpopSession, err := getExistingHabitatGorillaSession(r, w, h.sessionStore)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer dpopSession.Save(r, w)
+
+	htu := path.Join(h.htuURL, r.URL.Path)
+
+	// Get the key from the session
+	key, err := dpopSession.GetDpopKey()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Get PDS URL from session
+	pdsURL, err := dpopSession.GetPDSURL()
+	fmt.Println("PDS URL", pdsURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Parse PDS URL to get host and scheme
+	parsedPDSURL, err := url.Parse(pdsURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Unset the request URI (can't be set when used as a client)
+	r.RequestURI = ""
+	r.URL.Scheme = parsedPDSURL.Scheme
+	r.URL.Host = parsedPDSURL.Host
+	tokenInfo, err := dpopSession.GetTokenInfo()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	accessToken := tokenInfo.AccessToken
+	//r.Header.Set("Authorization", "DPoP "+accessToken)
+	r.Header.Del("Content-Length")
+
+	// Create nonce provider from session
+	nonceProvider := NewSessionNonceProvider(dpopSession)
+
+	pdsDpopClient := NewDpopHttpClient(key, NewSessionNonceProvider(dpopSession), WithHTU(htu), WithAccessToken(accessToken))
+
+	// Copy the request body without consuming it
+	bodyCopy, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyCopy))
+
+	// Forward the request to the PDS
+	resp, err := pdsDpopClient.Do(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Check if we need to refresh the token
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Try to refresh the token
+		authDpopClient := NewDpopHttpClient(key, nonceProvider)
+		identity, err := dpopSession.GetIdentity()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		issuer, err := dpopSession.GetIssuer()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		tokenResp, err := h.oauthClient.RefreshToken(authDpopClient, identity, issuer, tokenInfo.RefreshToken)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = dpopSession.SetTokenInfo(tokenResp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(bodyCopy))
+
+		refreshedDpopClient := NewDpopHttpClient(key, nonceProvider, WithHTU(htu), WithAccessToken(tokenResp.AccessToken))
+
+		// Retry the request with the new token
+		resp, err = refreshedDpopClient.Do(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+	}
+
+	// Writing out the response as we got it.
+
+	// Copy response headers before writing status code
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	// Write body last
+	defer resp.Body.Close()
+	_, err = io.Copy(w, resp.Body)
+	if err == http.ErrBodyReadAfterClose {
+		return
+	}
+}

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -57,7 +57,7 @@ func setupTestRequestWithSession(t *testing.T, sessionStore sessions.Store, opts
 	session, err := sessionStore.New(sessionReq, "dpop-session")
 	require.NoError(t, err)
 
-	dpopSession := &habitatGorillaSession{session: session, req: sessionReq, respWriter: sessionW}
+	dpopSession := &cookieSession{session: session}
 
 	err = dpopSession.SetDpopKey(key)
 	require.NoError(t, err)

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -113,7 +113,10 @@ func TestXrpcBrokerHandler_SuccessfulRequest(t *testing.T) {
 				"uri":   "at://did:plc:test123/app.bsky.feed.post/3juxg",
 				"value": map[string]interface{}{"text": "Hello world"},
 			}
-			json.NewEncoder(w).Encode(resp)
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -262,17 +265,23 @@ func TestXrpcBrokerHandler_SuccessfulTokenRefresh(t *testing.T) {
 		// Serve OAuth discovery endpoints on the PDS server
 		switch r.URL.Path {
 		case "/.well-known/oauth-protected-resource":
-			json.NewEncoder(w).Encode(oauthProtectedResource{
+			if err := json.NewEncoder(w).Encode(oauthProtectedResource{
 				AuthorizationServers: []string{fakeOAuthServer.URL + "/.well-known/oauth-authorization-server"},
-			})
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		case "/.well-known/oauth-authorization-server":
-			json.NewEncoder(w).Encode(oauthAuthorizationServer{
+			if err := json.NewEncoder(w).Encode(oauthAuthorizationServer{
 				Issuer:        "https://example.com",
 				TokenEndpoint: fakeOAuthServer.URL + "/token",
 				PAREndpoint:   fakeOAuthServer.URL + "/par",
 				AuthEndpoint:  fakeOAuthServer.URL + "/auth",
-			})
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 
@@ -288,7 +297,10 @@ func TestXrpcBrokerHandler_SuccessfulTokenRefresh(t *testing.T) {
 				"uri":   "at://did:plc:test123/app.bsky.feed.post/3juxg",
 				"value": map[string]interface{}{"text": "Hello world"},
 			}
-			json.NewEncoder(w).Encode(resp)
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -337,7 +349,10 @@ func TestXrpcBrokerHandler_RequestBodyHandling(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			w.Write(body)
+			if _, err := w.Write(body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)
@@ -423,7 +438,10 @@ func TestXrpcBrokerHandler_RequestBodyCopying(t *testing.T) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			w.Write(body)
+			if _, err := w.Write(body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 		http.Error(w, "not found", http.StatusNotFound)

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -1,0 +1,458 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/gorilla/sessions"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestXrpcBrokerHandler creates a xrpcBrokerHandler with test dependencies
+func setupTestXrpcBrokerHandler(t *testing.T, oauthClient OAuthClient, htuURL string) *xrpcBrokerHandler {
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	return &xrpcBrokerHandler{
+		htuURL:       htuURL,
+		oauthClient:  oauthClient,
+		sessionStore: sessionStore,
+	}
+}
+
+// setupTestXrpcBrokerHandlerWithSessionStore creates a xrpcBrokerHandler with a specific session store
+func setupTestXrpcBrokerHandlerWithSessionStore(t *testing.T, oauthClient OAuthClient, htuURL string, sessionStore sessions.Store) *xrpcBrokerHandler {
+	return &xrpcBrokerHandler{
+		htuURL:       htuURL,
+		oauthClient:  oauthClient,
+		sessionStore: sessionStore,
+	}
+}
+
+// setupTestRequestWithSession creates a test request with proper DPoP session cookies
+func setupTestRequestWithSession(t *testing.T, sessionStore sessions.Store, opts DpopSessionOptions) (*http.Request, *httptest.ResponseRecorder) {
+	// Create a test request and response writer for session creation
+	sessionReq := httptest.NewRequest("GET", "/test", nil)
+	sessionW := httptest.NewRecorder()
+
+	// Use provided identity or create a default one
+	var identity *identity.Identity
+	if opts.Identity != nil {
+		identity = opts.Identity
+	} else {
+		identity = testIdentity(opts.PdsURL)
+	}
+
+	// Create a fresh DPoP session without saving it yet
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	session, err := sessionStore.New(sessionReq, "dpop-session")
+	require.NoError(t, err)
+
+	dpopSession := &habitatGorillaSession{session: session, req: sessionReq, respWriter: sessionW}
+
+	err = dpopSession.SetDpopKey(key)
+	require.NoError(t, err)
+	err = dpopSession.SetIdentity(identity)
+	require.NoError(t, err)
+	err = dpopSession.SetPDSURL(opts.PdsURL)
+	require.NoError(t, err)
+
+	// Set issuer if provided
+	if opts.Issuer != nil {
+		dpopSession.session.Values[cIssuerSessionKey] = *opts.Issuer
+	}
+
+	// Set access token if provided
+	if opts.TokenInfo != nil {
+		err = dpopSession.SetTokenInfo(opts.TokenInfo)
+		require.NoError(t, err)
+	}
+
+	// Remove identity if explicitly requested
+	if opts.RemoveIdentity {
+		delete(dpopSession.session.Values, cIdentitySessionKey)
+	}
+
+	// Save the session only once at the end
+	err = dpopSession.session.Save(sessionReq, sessionW)
+	require.NoError(t, err)
+
+	// Create the actual request that will be used by the handler
+	req := httptest.NewRequest("POST", "/xrpc/com.atproto.repo.getRecord", nil)
+	w := httptest.NewRecorder()
+
+	// Add DPoP session cookies to the actual request
+	cookies := sessionW.Result().Cookies()
+	for _, cookie := range cookies {
+		fmt.Println("Cookie", cookie)
+		req.AddCookie(cookie)
+	}
+
+	return req, w
+}
+
+func TestXrpcBrokerHandler_SuccessfulRequest(t *testing.T) {
+	// This test verifies that the XRPC broker handler properly handles requests
+	// with a valid DPoP session and access token
+
+	// Setup mock PDS server that responds to XRPC requests
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/xrpc/com.atproto.repo.getRecord" {
+			// Return a mock record response
+			resp := map[string]interface{}{
+				"cid":   "bafyreidf6z3ac6n6f2n5bs2by2eqm6j7mv3gduq7q",
+				"uri":   "at://did:plc:test123/app.bsky.feed.post/3juxg",
+				"value": map[string]interface{}{"text": "Hello world"},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+
+	handler := &xrpcBrokerHandler{
+		htuURL:       "https://test.com",
+		oauthClient:  oauthClient,
+		sessionStore: sessionStore,
+	}
+
+	// Create request with valid DPoP session
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "test-access-token",
+			RefreshToken: "test-refresh-token",
+		},
+	})
+
+	// Set the correct path for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.getRecord"
+
+	handler.ServeHTTP(w, req)
+
+	// Should succeed with valid session
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, "bafyreidf6z3ac6n6f2n5bs2by2eqm6j7mv3gduq7q", response["cid"])
+}
+
+func TestXrpcBrokerHandler_NoDPOPSession(t *testing.T) {
+	oauthClient := testOAuthClient(t)
+	handler := setupTestXrpcBrokerHandler(t, oauthClient, "https://test.com")
+
+	req := httptest.NewRequest("POST", "/xrpc/com.atproto.repo.getRecord", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestXrpcBrokerHandler_UnauthorizedResponse(t *testing.T) {
+	// This test verifies that the XRPC broker handler properly handles unauthorized responses
+	// from the PDS (the hardcoded hostname issue has been fixed)
+
+	// Setup mock PDS server that returns unauthorized
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with valid DPoP session
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "expired-access-token",
+			RefreshToken: "test-refresh-token",
+		},
+	})
+
+	// Set the correct path for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.getRecord"
+
+	handler.ServeHTTP(w, req)
+
+	// Should fail due to token refresh error (no OAuth server configured)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "failed to fetch authorization server")
+}
+
+func TestXrpcBrokerHandler_RefreshTokenError(t *testing.T) {
+	// Setup mock PDS server that returns unauthorized
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer mockPDS.Close()
+
+	// Setup fake OAuth server that returns error for refresh
+	fakeOAuthServer := fakeTokenServer(t, map[string]interface{}{
+		"token-status": http.StatusBadRequest,
+		"token-error":  "invalid_grant",
+	})
+	defer fakeOAuthServer.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with DPoP session that has refresh token
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "expired-access-token",
+			RefreshToken: "invalid-refresh-token",
+		},
+	})
+
+	// Set the correct path for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.getRecord"
+
+	handler.ServeHTTP(w, req)
+
+	// Should fail due to OAuth server error (no server configured)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "failed to fetch authorization server")
+}
+
+func TestXrpcBrokerHandler_SuccessfulTokenRefresh(t *testing.T) {
+	// This test verifies that the XRPC broker handler can successfully refresh tokens
+	// when the PDS returns unauthorized
+
+	// Setup fake OAuth server that returns successful token refresh
+	fakeOAuthServer := fakeAuthServer(t, map[string]interface{}{
+		"token": TokenResponse{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			Scope:        "atproto transition:generic",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+		},
+	})
+	defer fakeOAuthServer.Close()
+
+	// Setup mock PDS server that returns unauthorized first, then success
+	// Also serves OAuth discovery endpoints
+	requestCount := 0
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		// Serve OAuth discovery endpoints on the PDS server
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			json.NewEncoder(w).Encode(oauthProtectedResource{
+				AuthorizationServers: []string{fakeOAuthServer.URL + "/.well-known/oauth-authorization-server"},
+			})
+			return
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(oauthAuthorizationServer{
+				Issuer:        "https://example.com",
+				TokenEndpoint: fakeOAuthServer.URL + "/token",
+				PAREndpoint:   fakeOAuthServer.URL + "/par",
+				AuthEndpoint:  fakeOAuthServer.URL + "/auth",
+			})
+			return
+		}
+
+		if requestCount == 1 {
+			// First request returns unauthorized
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		// Second request (after token refresh) returns success
+		if r.URL.Path == "/xrpc/com.atproto.repo.getRecord" {
+			resp := map[string]interface{}{
+				"cid":   "bafyreidf6z3ac6n6f2n5bs2by2eqm6j7mv3gduq7q",
+				"uri":   "at://did:plc:test123/app.bsky.feed.post/3juxg",
+				"value": map[string]interface{}{"text": "Hello world"},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with DPoP session that has refresh token
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "expired-access-token",
+			RefreshToken: "valid-refresh-token",
+		},
+	})
+
+	// Set the correct path for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.getRecord"
+
+	handler.ServeHTTP(w, req)
+
+	// Should succeed with token refresh
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, "bafyreidf6z3ac6n6f2n5bs2by2eqm6j7mv3gduq7q", response["cid"])
+}
+
+func TestXrpcBrokerHandler_RequestBodyHandling(t *testing.T) {
+	// This test verifies that the XRPC broker handler properly handles request bodies
+	// with a valid DPoP session
+
+	// Setup mock PDS server that responds to XRPC requests
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/xrpc/com.atproto.repo.putRecord" {
+			// Read and echo back the request body
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(body)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with body and valid DPoP session
+	requestBody := `{"collection": "app.bsky.feed.post", "repo": "did:plc:test123", "rkey": "3juxg", "value": {"text": "Hello world"}}`
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "test-access-token",
+			RefreshToken: "test-refresh-token",
+		},
+	})
+
+	// Set the correct path and body for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.putRecord"
+	req.Body = io.NopCloser(bytes.NewBufferString(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	handler.ServeHTTP(w, req)
+
+	// Should succeed and return the request body
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, requestBody, w.Body.String())
+
+}
+
+func TestXrpcBrokerHandler_ErrorResponse(t *testing.T) {
+	// This test verifies that the XRPC broker handler properly handles error responses
+	// from the PDS with a valid DPoP session
+
+	// Setup mock PDS server that returns an error
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/xrpc/com.atproto.repo.getRecord" {
+			http.Error(w, "record not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with valid DPoP session
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "test-access-token",
+			RefreshToken: "test-refresh-token",
+		},
+	})
+
+	// Set the correct path for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.getRecord"
+
+	handler.ServeHTTP(w, req)
+
+	// Should return the error from PDS
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "record not found")
+}
+
+func TestXrpcBrokerHandler_RequestBodyCopying(t *testing.T) {
+	// This test verifies that the XRPC broker handler properly handles large request bodies
+	// with a valid DPoP session
+
+	// Setup mock PDS server that echoes back the request body
+	mockPDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/xrpc/com.atproto.repo.putRecord" {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(body)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mockPDS.Close()
+
+	oauthClient := testOAuthClient(t)
+	sessionStore := sessions.NewCookieStore([]byte("test-key"))
+	handler := setupTestXrpcBrokerHandlerWithSessionStore(t, oauthClient, "https://test.com", sessionStore)
+
+	// Create request with large body and valid DPoP session
+	largeBody := bytes.Repeat([]byte("test"), 1000)
+	req, w := setupTestRequestWithSession(t, sessionStore, DpopSessionOptions{
+		PdsURL: mockPDS.URL,
+		Issuer: stringPtr("https://example.com"),
+		TokenInfo: &TokenResponse{
+			AccessToken:  "test-access-token",
+			RefreshToken: "test-refresh-token",
+		},
+	})
+
+	// Set the correct path and body for the request
+	req.URL.Path = "/xrpc/com.atproto.repo.putRecord"
+	req.Body = io.NopCloser(bytes.NewBuffer(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	handler.ServeHTTP(w, req)
+
+	// Should succeed and return the large body
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, string(largeBody), w.Body.String())
+}

--- a/internal/auth/broker_test.go
+++ b/internal/auth/broker_test.go
@@ -198,7 +198,7 @@ func TestXrpcBrokerHandler_UnauthorizedResponse(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	// Should fail due to token refresh error (no OAuth server configured)
-	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
 	require.Contains(t, w.Body.String(), "failed to fetch authorization server")
 }
 
@@ -236,7 +236,7 @@ func TestXrpcBrokerHandler_RefreshTokenError(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	// Should fail due to OAuth server error (no server configured)
-	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
 	require.Contains(t, w.Body.String(), "failed to fetch authorization server")
 }
 

--- a/internal/auth/dpop.go
+++ b/internal/auth/dpop.go
@@ -119,6 +119,8 @@ func (s *DpopHttpClient) Do(req *http.Request) (*http.Response, error) {
 
 	// retry with new nonce
 	req2 := req.Clone(req.Context())
+	req2.RequestURI = ""
+
 	req2.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	err = s.sign(req2)
 	if err != nil {

--- a/internal/auth/get_routes_test.go
+++ b/internal/auth/get_routes_test.go
@@ -20,5 +20,5 @@ func TestGetRoutes(t *testing.T) {
 	routes, err := GetRoutes(testConfig, sessionStore)
 	require.NoError(t, err)
 
-	require.Len(t, routes, 3)
+	require.Len(t, routes, 4)
 }

--- a/internal/auth/login_handler.go
+++ b/internal/auth/login_handler.go
@@ -82,6 +82,10 @@ func GetRoutes(
 		}, &callbackHandler{
 			oauthClient:  oauthClient,
 			sessionStore: sessionStore,
+		}, &xrpcBrokerHandler{
+			oauthClient:  oauthClient,
+			sessionStore: sessionStore,
+			htuURL:       nodeConfig.ExternalURL(),
 		},
 	}, nil
 }


### PR DESCRIPTION
[OAuth] Initial buggy implementation

Add proxy rules needed for PDS OAuth

Get PDS url from handle from internal PDS config if supplied

Fix some bugs with the DPoP client

- Reading of response body when use_dpop_nonce error occurs uses an unlimited buffer now
- Error handling for signing in the request
- Only read DPoP-Nonce header if a use dpop nonce error is detected
- DPoP private key session value is marshalled into a string (the key type wasn't allowed in the session)
- Auth token hash created using SHA256

Fix bugs in login_handler.go

- DPoP Gorilla session is saved without `defer` (was not being saved properly before)
- Fixed misnamed auth-session name
- Read access token from the token response properly

Hard coded configuration changes, fix later

Supply handle as login hint

Auth wip

Support custom PDS proxy rule

Inject sessionStore

Set a lot more info in the dpop session

htu claim is passed in

WIP PDS proxy rule

NewLoginHandler -> auth.GetRoutes

Fixup how htu is passed into Dpop client and overridden

Fixup dpopclient.Do

Add XRPC broker endpoint that forwards PDS requests to PDS with proper auth info

Remove PDS proxy rule

A JWKBuilder must be injected into the DPoP Client

Cleanup

Handle token refresh in test endpoint

Refactor jwks

Factor out DPoP session

Handle refresh token in broker

Fix some error strings in oauth client

More rb remove session store

Proper errror handling in session

Login handler test

Remove some hard coding

Oauth  client tests

Update login handler tests

Handler tests wip

Finish XRPC Broker tests

Routes test

Update logout to clear new cookies for gorilla sessions

Only allow Oauth login

Frontend fix wip