### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6.0.0
       with:
-        version: v1.60
+        version: v1.64.8
 
     - name: Test
       run: go test ./... -coverprofile=coverage.out -coverpkg=./...


### PR DESCRIPTION
Bump golangci-lint version

Bump golangci-lint version to 1.64.8 to get around bugs